### PR TITLE
Adjust DAOS yaml config file

### DIFF
--- a/images/configs/daos_agent.yml
+++ b/images/configs/daos_agent.yml
@@ -1,17 +1,3 @@
-# Copyright 2021 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 access_points: [changeap]
 transport_config:
   allow_insecure: true

--- a/images/configs/daos_control.yml
+++ b/images/configs/daos_control.yml
@@ -1,17 +1,3 @@
-# Copyright 2021 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 hostlist: [changehosts]
 transport_config:
   allow_insecure: true

--- a/images/configs/daos_server.yml
+++ b/images/configs/daos_server.yml
@@ -1,25 +1,11 @@
-# Copyright 2021 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 access_points: [changeap]
 transport_config:
   allow_insecure: true
 provider: ofi+tcp;ofi_rxm
 disable_vfio: true
-disable_vmd: true
+crt_timeout: 200
 
-servers:
+engines:
 -
    targets: 8
    nr_xs_helpers: 0


### PR DESCRIPTION
Remove license header from yaml config files.
Use "engines:" instead of "servers:" in daos_server.yml.
Bump crt_timeout to 200s

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>