### PR TITLE
Update SPDK RPMs to work around NVMe get-feature issue

### DIFF
--- a/examples/daos_client_mig/README.md
+++ b/examples/daos_client_mig/README.md
@@ -1,17 +1,3 @@
-Copyright 2021 Google LLC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
 # DAOS Client MIG
 
 Creates a managed instance group running ```number_of_instances``` DAOS clients.

--- a/examples/simple_daos_server_example/README.md
+++ b/examples/simple_daos_server_example/README.md
@@ -1,17 +1,3 @@
-Copyright 2021 Google LLC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
 # DAOS Server Simple Example
 
 Creates a managed instance group running ```number_of_instances``` DAOS servers.

--- a/images/README.md
+++ b/images/README.md
@@ -1,4 +1,4 @@
-# Daos Images
+# DAOS Images
 
 This file describes how to build a DAOS client and server images
 
@@ -6,7 +6,10 @@ This file describes how to build a DAOS client and server images
 We leverage cloud build and use a packer container image that we assume exists in your project.
 If you have not build the Packer container image please do so now before continuing.
 
-Please visit the tutorial [quickstart-packer](https://cloud.google.com/cloud-build/docs/quickstart-packer). You can leverage code from [cloud-builders-community](https://github.com/GoogleCloudPlatform/cloud-builders-community.git) is the first step (the [packer folder](https://github.com/GoogleCloudPlatform/cloud-builders-community/tree/master/packer)). You must have a packer docker container in your project in order for the rest of the scripts in this repository to work.
+Please visit the tutorial [quickstart-packer](https://cloud.google.com/cloud-build/docs/quickstart-packer).
+You can leverage code from [cloud-builders-community](https://github.com/GoogleCloudPlatform/cloud-builders-community.git)
+is the first step (the [packer folder](https://github.com/GoogleCloudPlatform/cloud-builders-community/tree/master/packer)).
+You must have a packer docker container in your project in order for the rest of the scripts in this repository to work.
 
 
 ## Make a DAOS server image

--- a/images/scripts/install-client.sh
+++ b/images/scripts/install-client.sh
@@ -16,16 +16,6 @@
 
 echo "Installing DAOS version ${DAOS_VERSION}"
 
-# Install 1.1.4 from non-official site for now
-tee /etc/yum.repos.d/daos.repo > /dev/null <<EOF
-[daos]
-name=daos (packages.daos.io)
-baseurl=http://packages.daos.io/private/1c648136-2100-486b-83b4-002222a45bee/v1.1.4/CentOS7/
-enabled=1
-gpgcheck=0
-repo_gpgcheck=0
-EOF
-
 # Install 1.2.0 RPMs from official site
 tee /etc/yum.repos.d/daos.repo > /dev/null <<EOF
 [daos-packages]

--- a/images/scripts/install.sh
+++ b/images/scripts/install.sh
@@ -37,5 +37,11 @@ EOF
 # Install DAOS RPMs
 yum install -y daos-server
 
+# Upgrade SPDK to work around the GCP NVMe bug with number of qpairs
+yum install -y wget
+wget https://packages.daos.io/v1.2/CentOS7/spdk/x86_64/spdk-20.01.2-2.el7.x86_64.rpm
+wget https://packages.daos.io/v1.2/CentOS7/spdk/x86_64/spdk-tools-20.01.2-2.el7.noarch.rpm
+rpm -Uvh ./spdk-20.01.2-2.el7.x86_64.rpm ./spdk-tools-20.01.2-2.el7.noarch.rpm
+
 # TODO:
 # - enable gvnic

--- a/modules/daos_client/README.md
+++ b/modules/daos_client/README.md
@@ -1,17 +1,3 @@
-Copyright 2021 Google LLC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
 # DAOS Client module
 
 This module creates a managed instance group of DAOS clients on GCP.

--- a/modules/daos_server/README.md
+++ b/modules/daos_server/README.md
@@ -1,17 +1,3 @@
-Copyright 2021 Google LLC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
 # DAOS Server module
 
 This module creates a opinionated deployment of DAOS on GCP.


### PR DESCRIPTION
$ nvme get-feature /dev/nvme0 -f 7
get-feature:0x7 (Number of Queues), Current value:00000000

Value is 00000000 which means that this SSD is reporting it only
has 1 qpair (1 submission queue and 1 completion queue).

Backport a SPDK patch to work around this issue.

Remove leftover from 1.1.4 and license from README file.
Install updated SPDK RPMs with workaround for NVMe bug

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>