### PR TITLE
DAOS-9673 Fix for 1 server 1 client error in IO500 example

### DIFF
--- a/terraform/examples/io500/configure.sh
+++ b/terraform/examples/io500/configure.sh
@@ -97,8 +97,6 @@ do
     echo ${CLIENT_NAME}-$(printf %04d ${i})>>hosts
 done
 
-cat hosts | tail -n+2 > hosts_no_first
-
 for ((i=1; i <= ${DAOS_SERVER_INSTANCE_COUNT} ; i++))
 do
     SERVERS+="${SERVER_NAME}-$(printf %04d ${i}) "

--- a/terraform/examples/io500/run_io500-sc21.sh
+++ b/terraform/examples/io500/run_io500-sc21.sh
@@ -60,16 +60,14 @@ pdcp -w ^hosts install_*.sh ~
 if [[ ! -d /usr/local/mpifileutils/install/bin ]]
 then
   printf "\nRun install_mpifileutils.sh on client nodes\n\n"
-  sudo ./install_mpifileutils.sh
-  pdsh -w ^hosts_no_first "sudo ./install_mpifileutils.sh"
+  pdsh -w ^hosts "sudo ./install_mpifileutils.sh"
 fi
 
 # Install IO500 if not already installed
 if [[ ! -d "${IO500_DIR}" ]]
 then
   printf "\nRun install_${IO500_VERSION_TAG,,}.sh on client nodes\n\n"
-  sudo "./install_${IO500_VERSION_TAG}.sh"
-  pdsh -w ^hosts_no_first "sudo ./install_${IO500_VERSION_TAG,,}.sh"
+  pdsh -w ^hosts "sudo ./install_${IO500_VERSION_TAG,,}.sh"
 fi
 
 cleanup


### PR DESCRIPTION
This fixes a bug introduced in PR#9 that causes the run_io500-sc21.sh
script to fail in a 1 server 1 client configuration.

Signed-off-by: Mark A. Olson <mark.a.olson@intel.com>