### PR TITLE
DAOS-9737 Add pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+---
+repos:
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.64.0
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_tflint
+        args:
+          - --args=--config=__GIT_WORKING_DIR__/.tflint.hcl
+      - id: terraform_validate
+  - repo: local
+    hooks:
+      - id: terraform-readme
+        name: terraform-readme
+        entry: tools/autodoc/terraform_docs.sh
+        language: script
+        types: ['terraform']
+        exclude: \.terraform\/.*$
+        pass_filenames: true
+        require_serial: true
+      - id: packer-readme
+        name: packer-readme
+        entry: tools/autodoc/terraform_docs.sh
+        language: script
+        files: ^.*\.pkr\.hcl$
+        pass_filenames: true
+        require_serial: true

--- a/.tfdocs-json.yaml
+++ b/.tfdocs-json.yaml
@@ -1,0 +1,25 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+formatter: json
+
+# do not use lockfile to determine version ranges placed into docs
+settings:
+  lockfile: false
+
+output:
+  file: module.json
+  mode: replace
+  template: |
+    {{ .Content }}

--- a/.tfdocs-markdown.yaml
+++ b/.tfdocs-markdown.yaml
@@ -1,0 +1,27 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+formatter: markdown
+
+# do not use lockfile to determine version ranges placed into docs
+settings:
+  lockfile: false
+
+output:
+  file: README.md
+  mode: inject
+  template: |-
+    <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+    {{ .Content }}
+    <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,38 @@
+plugin "google" {
+  enabled = true
+  version = "0.12.1"
+  source  = "github.com/terraform-linters/tflint-ruleset-google"
+}
+rule "terraform_deprecated_index" {
+  enabled = true
+}
+rule "terraform_unused_declarations" {
+  enabled = true
+}
+rule "terraform_documented_variables" {
+  enabled = true
+}
+rule "terraform_comment_syntax" {
+  enabled = true
+}
+rule "terraform_documented_outputs" {
+  enabled = true
+}
+rule "terraform_documented_variables" {
+  enabled = true
+}
+rule "terraform_typed_variables" {
+  enabled = true
+}
+rule "terraform_naming_convention" {
+  enabled = true
+}
+rule "terraform_required_version" {
+  enabled = true
+}
+rule "terraform_required_providers" {
+  enabled = true
+}
+rule "terraform_unused_required_providers" {
+  enabled = true
+}

--- a/README.md
+++ b/README.md
@@ -5,3 +5,17 @@ This repository contains scripts to deploy DAOS on GCP.
 It consists of the directories:
 - [images](images) - which contains scripts to prepare DAOS images for GCP used by Terraform code
 - [terraform](terraform) - which contains Terraform code used to deploy DAOS on GCP
+
+## Dependencies
+
+In order to build images and deploy DAOS instances in Google Cloud Compute Engine you must have the following software installed.
+
+- [git](https://git-scm.com/)
+- [Google Cloud SDK](https://cloud.google.com/sdk/docs/install)
+- [Packer](https://www.packer.io/downloads)
+- [Terraform](https://www.terraform.io/downloads)
+
+## Development
+
+See [Development - google-cloud-daos ](docs/development.md)
+

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,76 @@
+# Development - google-cloud-daos
+
+Please use the [pre-commit](https://pre-commit.com/) hooks configured in this repository to ensure that all Terraform modules are validated and properly documented before pushing code changes.
+
+
+## Install pre-commit and dependencies
+
+In order to use [pre-commit](https://pre-commit.com/) you will need to install it on your system.
+
+You will also need to install the dependencies that are required for the pre-commit plugins used in this repository.
+
+1. Install [pre-commit](https://pre-commit.com/).
+
+   [pre-commit](https://pre-commit.com/) can be installed using standard package managers.
+
+   Instructions can be found at the [pre-commit website](https://pre-commit.com/#install).
+
+
+2. Install [TFLint](https://github.com/terraform-linters/tflint)
+
+   See the [installation instructions](https://github.com/terraform-linters/tflint#installation)
+
+   After installing tflint change into the root of the locally cloned git repo and run the `init` command.
+
+   ```shell
+   cd <root of google-cloud-daos repo>
+   tflint init
+   ```
+
+3. *OPTIONAL* - MacOS only
+
+   MacOS users will need to install `findutils` and `coreutils`.
+
+   Before installing coreutils read the
+   [gotchas about coreutils](https://www.pixelbeat.org/docs/coreutils-gotchas.html)
+   to ensure that the installation will not negatively impact your
+   system.
+
+   **Homebrew**
+
+   ```shell
+   brew install findutils
+   brew install coreutils
+   ```
+
+   **Conda**
+
+   ```shell
+   brew install findutils
+   conda install coreutils
+   ```
+
+   Update your PATH  in your `~/.bashrc` or `~/.bash_profile`
+   ```shell
+   PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
+   ```
+
+## Install the pre-commit hook
+
+After you have installed [pre-commit](https://pre-commit.com/) and its dependencies on your system you can need to install the pre-commit hook in
+your local clone of the google-cloud-daos git repository.
+
+```shell
+cd <root of google-cloud-daos repo>
+pre-commit install
+```
+
+## Running pre-commit
+
+[pre-commit](https://pre-commit.com/) will now run on any files that are staged when you run `git commit -s`.
+
+To run [pre-commit](https://pre-commit.com/) on all files prior to staging them
+
+```shell
+pre-commit run --all-files
+```

--- a/terraform/examples/daos_client_mig/README.md
+++ b/terraform/examples/daos_client_mig/README.md
@@ -34,6 +34,7 @@ No resources.
 | <a name="input_instance_base_name"></a> [instance\_base\_name](#input\_instance\_base\_name) | MIG instance base names to use | `string` | `"daos-client"` | no |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | GCP machine type. ie. e2-medium | `string` | `"n2-highmem-16"` | no |
 | <a name="input_mig_name"></a> [mig\_name](#input\_mig\_name) | MIG name | `string` | `"daos-client"` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Set of key/value label pairs to assign to daos-client instances | `any` | n/a | no |
 | <a name="input_network"></a> [network](#input\_network) | GCP network to use | `string` | n/a | yes |
 | <a name="input_number_of_instances"></a> [number\_of\_instances](#input\_number\_of\_instances) | Number of daos clients to bring up | `number` | `2` | no |
 | <a name="input_os_disk_size_gb"></a> [os\_disk\_size\_gb](#input\_os\_disk\_size\_gb) | OS disk size in GB | `number` | `20` | no |

--- a/terraform/examples/daos_client_mig/README.md
+++ b/terraform/examples/daos_client_mig/README.md
@@ -51,3 +51,65 @@ No resources.
 ## Outputs
 
 No outputs.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2021 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.5 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.54.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_daos_client"></a> [daos\_client](#module\_daos\_client) | ../../modules/daos_client | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_instance_base_name"></a> [instance\_base\_name](#input\_instance\_base\_name) | MIG instance base names to use | `string` | `"daos-client"` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Set of key/value label pairs to assign to daos-client instances | `any` | `{}` | no |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | GCP machine type. ie. e2-medium | `string` | `"n2-highmem-16"` | no |
+| <a name="input_mig_name"></a> [mig\_name](#input\_mig\_name) | MIG name | `string` | `"daos-client"` | no |
+| <a name="input_network"></a> [network](#input\_network) | GCP network to use | `string` | n/a | yes |
+| <a name="input_number_of_instances"></a> [number\_of\_instances](#input\_number\_of\_instances) | Number of daos clients to bring up | `number` | `2` | no |
+| <a name="input_os_disk_size_gb"></a> [os\_disk\_size\_gb](#input\_os\_disk\_size\_gb) | OS disk size in GB | `number` | `20` | no |
+| <a name="input_os_disk_type"></a> [os\_disk\_type](#input\_os\_disk\_type) | OS disk type ie. pd-ssd, pd-standard | `string` | `"pd-ssd"` | no |
+| <a name="input_os_family"></a> [os\_family](#input\_os\_family) | OS GCP image family | `string` | `null` | no |
+| <a name="input_os_project"></a> [os\_project](#input\_os\_project) | OS GCP image project name | `string` | `null` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project to use | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | The GCP region to create and test resources in | `string` | n/a | yes |
+| <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | GCP sub-network to use | `string` | n/a | yes |
+| <a name="input_subnetwork_project"></a> [subnetwork\_project](#input\_subnetwork\_project) | The GCP project where the subnetwork is defined | `string` | n/a | yes |
+| <a name="input_template_name"></a> [template\_name](#input\_template\_name) | MIG template name | `string` | `"daos-client"` | no |
+| <a name="input_zone"></a> [zone](#input\_zone) | The GCP zone to create and test resources in | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/terraform/examples/daos_client_mig/main.tf
+++ b/terraform/examples/daos_client_mig/main.tf
@@ -26,6 +26,7 @@ module "daos_client" {
   subnetwork_project = var.subnetwork_project
   region             = var.region
   zone               = var.zone
+  labels             = var.labels
 
   number_of_instances = var.number_of_instances
 

--- a/terraform/examples/daos_client_mig/module.json
+++ b/terraform/examples/daos_client_mig/module.json
@@ -1,0 +1,139 @@
+{
+  "header": "Copyright 2021 Google LLC\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n     http://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.",
+  "footer": "",
+  "inputs": [
+    {
+      "name": "instance_base_name",
+      "type": "string",
+      "description": "MIG instance base names to use",
+      "default": "daos-client",
+      "required": false
+    },
+    {
+      "name": "labels",
+      "type": "any",
+      "description": "Set of key/value label pairs to assign to daos-client instances",
+      "default": {},
+      "required": false
+    },
+    {
+      "name": "machine_type",
+      "type": "string",
+      "description": "GCP machine type. ie. e2-medium",
+      "default": "n2-highmem-16",
+      "required": false
+    },
+    {
+      "name": "mig_name",
+      "type": "string",
+      "description": "MIG name ",
+      "default": "daos-client",
+      "required": false
+    },
+    {
+      "name": "network",
+      "type": "string",
+      "description": "GCP network to use",
+      "default": null,
+      "required": true
+    },
+    {
+      "name": "number_of_instances",
+      "type": "number",
+      "description": "Number of daos clients to bring up",
+      "default": 2,
+      "required": false
+    },
+    {
+      "name": "os_disk_size_gb",
+      "type": "number",
+      "description": "OS disk size in GB",
+      "default": 20,
+      "required": false
+    },
+    {
+      "name": "os_disk_type",
+      "type": "string",
+      "description": "OS disk type ie. pd-ssd, pd-standard",
+      "default": "pd-ssd",
+      "required": false
+    },
+    {
+      "name": "os_family",
+      "type": "string",
+      "description": "OS GCP image family",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "os_project",
+      "type": "string",
+      "description": "OS GCP image project name",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "project_id",
+      "type": "string",
+      "description": "The GCP project to use ",
+      "default": null,
+      "required": true
+    },
+    {
+      "name": "region",
+      "type": "string",
+      "description": "The GCP region to create and test resources in",
+      "default": null,
+      "required": true
+    },
+    {
+      "name": "subnetwork",
+      "type": "string",
+      "description": "GCP sub-network to use",
+      "default": null,
+      "required": true
+    },
+    {
+      "name": "subnetwork_project",
+      "type": "string",
+      "description": "The GCP project where the subnetwork is defined",
+      "default": null,
+      "required": true
+    },
+    {
+      "name": "template_name",
+      "type": "string",
+      "description": "MIG template name",
+      "default": "daos-client",
+      "required": false
+    },
+    {
+      "name": "zone",
+      "type": "string",
+      "description": "The GCP zone to create and test resources in",
+      "default": null,
+      "required": true
+    }
+  ],
+  "modules": [
+    {
+      "name": "daos_client",
+      "source": "../../modules/daos_client",
+      "version": "",
+      "description": null
+    }
+  ],
+  "outputs": [],
+  "providers": [],
+  "requirements": [
+    {
+      "name": "terraform",
+      "version": "\u003e= 0.14.5"
+    },
+    {
+      "name": "google",
+      "version": "\u003e= 3.54.0"
+    }
+  ],
+  "resources": []
+}

--- a/terraform/examples/daos_client_mig/terraform.tfvars.example
+++ b/terraform/examples/daos_client_mig/terraform.tfvars.example
@@ -4,6 +4,9 @@ subnetwork = "<my_VPC_subnetwork>"
 subnetwork_project = "<my_project_id>"
 region = "europe-west4"
 zone = "europe-west4-a"
+labels = {
+  example="daos_client_mig"
+}
 
 number_of_instances = 2
 

--- a/terraform/examples/daos_client_mig/variables.tf
+++ b/terraform/examples/daos_client_mig/variables.tf
@@ -27,6 +27,12 @@ variable "zone" {
   type        = string
 }
 
+variable "labels" {
+  description = "Set of key/value label pairs to assign to daos-client instances"
+  type        = any
+  default     = {}
+}
+
 variable "os_family" {
   description = "OS GCP image family"
   default     = null

--- a/terraform/examples/daos_client_mig/variables.tf
+++ b/terraform/examples/daos_client_mig/variables.tf
@@ -36,11 +36,13 @@ variable "labels" {
 variable "os_family" {
   description = "OS GCP image family"
   default     = null
+  type        = string
 }
 
 variable "os_project" {
   description = "OS GCP image project name"
   default     = null
+  type        = string
 }
 
 variable "os_disk_size_gb" {

--- a/terraform/examples/daos_client_mig/versions.tf
+++ b/terraform/examples/daos_client_mig/versions.tf
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+terraform {
+  required_version = ">= 0.14.5"
+  required_providers {
+    google = ">= 3.54.0"
+  }
+}

--- a/terraform/examples/full_cluster_setup/README.md
+++ b/terraform/examples/full_cluster_setup/README.md
@@ -19,3 +19,64 @@ To destroy DAOS environment, use below command:
 ```
 terraform destroy
 ```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.5 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.54.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_daos_client"></a> [daos\_client](#module\_daos\_client) | ../../modules/daos_client | n/a |
+| <a name="module_daos_server"></a> [daos\_server](#module\_daos\_server) | ../../modules/daos_server | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_client_instance_base_name"></a> [client\_instance\_base\_name](#input\_client\_instance\_base\_name) | MIG instance base names to use | `string` | `null` | no |
+| <a name="input_client_labels"></a> [client\_labels](#input\_client\_labels) | Set of key/value label pairs to assign to daos-client instances | `any` | `{}` | no |
+| <a name="input_client_machine_type"></a> [client\_machine\_type](#input\_client\_machine\_type) | GCP machine type. e.g. e2-medium | `string` | `null` | no |
+| <a name="input_client_mig_name"></a> [client\_mig\_name](#input\_client\_mig\_name) | MIG name | `string` | `null` | no |
+| <a name="input_client_number_of_instances"></a> [client\_number\_of\_instances](#input\_client\_number\_of\_instances) | Number of daos servers to bring up | `number` | `null` | no |
+| <a name="input_client_os_disk_size_gb"></a> [client\_os\_disk\_size\_gb](#input\_client\_os\_disk\_size\_gb) | OS disk size in GB | `number` | `20` | no |
+| <a name="input_client_os_disk_type"></a> [client\_os\_disk\_type](#input\_client\_os\_disk\_type) | OS disk type e.g. pd-ssd, pd-standard | `string` | `"pd-ssd"` | no |
+| <a name="input_client_os_family"></a> [client\_os\_family](#input\_client\_os\_family) | OS GCP image family | `string` | `null` | no |
+| <a name="input_client_os_project"></a> [client\_os\_project](#input\_client\_os\_project) | OS GCP image project name | `string` | `null` | no |
+| <a name="input_client_template_name"></a> [client\_template\_name](#input\_client\_template\_name) | MIG template name | `string` | `null` | no |
+| <a name="input_network"></a> [network](#input\_network) | GCP network to use | `string` | `null` | no |
+| <a name="input_preemptible"></a> [preemptible](#input\_preemptible) | If preemptible instances | `string` | `true` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project to use | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | The GCP region to create and test resources in | `string` | `null` | no |
+| <a name="input_server_daos_disk_count"></a> [server\_daos\_disk\_count](#input\_server\_daos\_disk\_count) | Number of local ssd's to use | `number` | `null` | no |
+| <a name="input_server_instance_base_name"></a> [server\_instance\_base\_name](#input\_server\_instance\_base\_name) | MIG instance base names to use | `string` | `null` | no |
+| <a name="input_server_labels"></a> [server\_labels](#input\_server\_labels) | Set of key/value label pairs to assign to daos-server instances | `any` | `{}` | no |
+| <a name="input_server_machine_type"></a> [server\_machine\_type](#input\_server\_machine\_type) | GCP machine type. e.g. e2-medium | `string` | `null` | no |
+| <a name="input_server_mig_name"></a> [server\_mig\_name](#input\_server\_mig\_name) | MIG name | `string` | `null` | no |
+| <a name="input_server_number_of_instances"></a> [server\_number\_of\_instances](#input\_server\_number\_of\_instances) | Number of daos servers to bring up | `number` | `null` | no |
+| <a name="input_server_os_disk_size_gb"></a> [server\_os\_disk\_size\_gb](#input\_server\_os\_disk\_size\_gb) | OS disk size in GB | `number` | `20` | no |
+| <a name="input_server_os_disk_type"></a> [server\_os\_disk\_type](#input\_server\_os\_disk\_type) | OS disk type e.g. pd-ssd, pd-standard | `string` | `"pd-ssd"` | no |
+| <a name="input_server_os_family"></a> [server\_os\_family](#input\_server\_os\_family) | OS GCP image family | `string` | `null` | no |
+| <a name="input_server_os_project"></a> [server\_os\_project](#input\_server\_os\_project) | OS GCP image project name | `string` | `null` | no |
+| <a name="input_server_template_name"></a> [server\_template\_name](#input\_server\_template\_name) | MIG template name | `string` | `null` | no |
+| <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | GCP sub-network to use | `string` | `null` | no |
+| <a name="input_subnetwork_project"></a> [subnetwork\_project](#input\_subnetwork\_project) | The GCP project where the subnetwork is defined | `string` | `null` | no |
+| <a name="input_zone"></a> [zone](#input\_zone) | The GCP zone to create and test resources in | `string` | `null` | no |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/terraform/examples/full_cluster_setup/main.tf
+++ b/terraform/examples/full_cluster_setup/main.tf
@@ -10,6 +10,7 @@ module "daos_server" {
   subnetwork_project = var.subnetwork_project
   region             = var.region
   zone               = var.zone
+  labels             = var.server_labels
 
   number_of_instances = var.server_number_of_instances
   daos_disk_count     = var.server_daos_disk_count
@@ -33,6 +34,7 @@ module "daos_client" {
   subnetwork_project = var.subnetwork_project
   region             = var.region
   zone               = var.zone
+  labels             = var.client_labels
 
   number_of_instances = var.client_number_of_instances
 

--- a/terraform/examples/full_cluster_setup/module.json
+++ b/terraform/examples/full_cluster_setup/module.json
@@ -1,0 +1,229 @@
+{
+  "header": "",
+  "footer": "",
+  "inputs": [
+    {
+      "name": "client_instance_base_name",
+      "type": "string",
+      "description": "MIG instance base names to use",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "client_labels",
+      "type": "any",
+      "description": "Set of key/value label pairs to assign to daos-client instances",
+      "default": {},
+      "required": false
+    },
+    {
+      "name": "client_machine_type",
+      "type": "string",
+      "description": "GCP machine type. e.g. e2-medium",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "client_mig_name",
+      "type": "string",
+      "description": "MIG name ",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "client_number_of_instances",
+      "type": "number",
+      "description": "Number of daos servers to bring up",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "client_os_disk_size_gb",
+      "type": "number",
+      "description": "OS disk size in GB",
+      "default": 20,
+      "required": false
+    },
+    {
+      "name": "client_os_disk_type",
+      "type": "string",
+      "description": "OS disk type e.g. pd-ssd, pd-standard",
+      "default": "pd-ssd",
+      "required": false
+    },
+    {
+      "name": "client_os_family",
+      "type": "string",
+      "description": "OS GCP image family",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "client_os_project",
+      "type": "string",
+      "description": "OS GCP image project name",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "client_template_name",
+      "type": "string",
+      "description": "MIG template name",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "network",
+      "type": "string",
+      "description": "GCP network to use",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "preemptible",
+      "type": "string",
+      "description": "If preemptible instances",
+      "default": true,
+      "required": false
+    },
+    {
+      "name": "project_id",
+      "type": "string",
+      "description": "The GCP project to use ",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "region",
+      "type": "string",
+      "description": "The GCP region to create and test resources in",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "server_daos_disk_count",
+      "type": "number",
+      "description": "Number of local ssd's to use",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "server_instance_base_name",
+      "type": "string",
+      "description": "MIG instance base names to use",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "server_labels",
+      "type": "any",
+      "description": "Set of key/value label pairs to assign to daos-server instances",
+      "default": {},
+      "required": false
+    },
+    {
+      "name": "server_machine_type",
+      "type": "string",
+      "description": "GCP machine type. e.g. e2-medium",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "server_mig_name",
+      "type": "string",
+      "description": "MIG name ",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "server_number_of_instances",
+      "type": "number",
+      "description": "Number of daos servers to bring up",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "server_os_disk_size_gb",
+      "type": "number",
+      "description": "OS disk size in GB",
+      "default": 20,
+      "required": false
+    },
+    {
+      "name": "server_os_disk_type",
+      "type": "string",
+      "description": "OS disk type e.g. pd-ssd, pd-standard",
+      "default": "pd-ssd",
+      "required": false
+    },
+    {
+      "name": "server_os_family",
+      "type": "string",
+      "description": "OS GCP image family",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "server_os_project",
+      "type": "string",
+      "description": "OS GCP image project name",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "server_template_name",
+      "type": "string",
+      "description": "MIG template name",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "subnetwork",
+      "type": "string",
+      "description": "GCP sub-network to use",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "subnetwork_project",
+      "type": "string",
+      "description": "The GCP project where the subnetwork is defined",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "zone",
+      "type": "string",
+      "description": "The GCP zone to create and test resources in",
+      "default": null,
+      "required": false
+    }
+  ],
+  "modules": [
+    {
+      "name": "daos_client",
+      "source": "../../modules/daos_client",
+      "version": "",
+      "description": null
+    },
+    {
+      "name": "daos_server",
+      "source": "../../modules/daos_server",
+      "version": "",
+      "description": null
+    }
+  ],
+  "outputs": [],
+  "providers": [],
+  "requirements": [
+    {
+      "name": "terraform",
+      "version": "\u003e= 0.14.5"
+    },
+    {
+      "name": "google",
+      "version": "\u003e= 3.54.0"
+    }
+  ],
+  "resources": []
+}

--- a/terraform/examples/full_cluster_setup/terraform.tfvars.example
+++ b/terraform/examples/full_cluster_setup/terraform.tfvars.example
@@ -16,6 +16,9 @@ server_mig_name            = "daos-server"
 server_machine_type        = "n2-highmem-32"
 server_os_project          = ""
 server_os_family           = "daos-server-centos-7"
+server_labels = {
+  example = "full_cluster_setup"
+}
 # Client
 client_number_of_instances = 1
 client_instance_base_name  = "daos-client"
@@ -26,3 +29,6 @@ client_mig_name            = "daos-client"
 client_machine_type        = "c2-standard-16"
 client_os_project          = ""
 client_os_family           = "daos-client-hpc-centos-7"
+client_labels = {
+  example = "full_cluster_setup"
+}

--- a/terraform/examples/full_cluster_setup/variables.tf
+++ b/terraform/examples/full_cluster_setup/variables.tf
@@ -153,30 +153,14 @@ variable "client_number_of_instances" {
   type        = number
 }
 
-variable "daos_disk_type" {
-  description = "Daos disk type to use. For now only suported one is local-ssd"
-  default     = "local-ssd"
-  type        = string
-}
-
 variable "server_daos_disk_count" {
   description = "Number of local ssd's to use"
   default     = null
   type        = number
 }
 
-variable "daos_service_account_scopes" {
-  description = "Scopes for the DAOS server service account"
-  default = [
-    "userinfo-email",
-    "compute-ro",
-    "storage-ro"
-  ]
-  type = list(string)
-}
-
 variable "preemptible" {
   description = "If preemptible instances"
-  default = true
-  type = string
+  default     = true
+  type        = string
 }

--- a/terraform/examples/full_cluster_setup/variables.tf
+++ b/terraform/examples/full_cluster_setup/variables.tf
@@ -14,6 +14,19 @@ variable "zone" {
   default     = null
 }
 
+variable "server_labels" {
+  description = "Set of key/value label pairs to assign to daos-server instances"
+  type        = any
+  default     = {}
+}
+
+variable "client_labels" {
+  description = "Set of key/value label pairs to assign to daos-client instances"
+  type        = any
+  default     = {}
+}
+
+
 variable "server_os_family" {
   description = "OS GCP image family"
   default     = null

--- a/terraform/examples/full_cluster_setup/versions.tf
+++ b/terraform/examples/full_cluster_setup/versions.tf
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+terraform {
+  required_version = ">= 0.14.5"
+  required_providers {
+    google = ">= 3.54.0"
+  }
+}

--- a/terraform/examples/io500/config/config.sh
+++ b/terraform/examples/io500/config/config.sh
@@ -13,7 +13,7 @@
 ID=""
 
 # Server and client instances
-PREEMPTIBLE_INSTANCES="true"
+PREEMPTIBLE_INSTANCES="false"
 SSH_USER="daos-user"
 
 # Server(s)

--- a/terraform/examples/simple_daos_server_example/README.md
+++ b/terraform/examples/simple_daos_server_example/README.md
@@ -31,6 +31,7 @@ No resources.
 |------|-------------|------|---------|:--------:|
 | <a name="input_daos_disk_count"></a> [daos\_disk\_count](#input\_daos\_disk\_count) | Number of local ssd's to use | `number` | `16` | no |
 | <a name="input_instance_base_name"></a> [instance\_base\_name](#input\_instance\_base\_name) | MIG instance base names to use | `string` | `"daos-server"` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Set of key/value label pairs to assign to daos-server instances | `any` | n/a | no |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | GCP machine type. ie. e2-medium | `string` | `"n2-custom-20-131072"` | no |
 | <a name="input_mig_name"></a> [mig\_name](#input\_mig\_name) | MIG name | `string` | `"daos-server"` | no |
 | <a name="input_network"></a> [network](#input\_network) | GCP network to use | `string` | n/a | yes |

--- a/terraform/examples/simple_daos_server_example/README.md
+++ b/terraform/examples/simple_daos_server_example/README.md
@@ -50,3 +50,66 @@ No resources.
 ## Outputs
 
 No outputs.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2021 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.5 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.54.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_daos_server"></a> [daos\_server](#module\_daos\_server) | ../../modules/daos_server | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_daos_disk_count"></a> [daos\_disk\_count](#input\_daos\_disk\_count) | Number of local ssd's to use | `number` | `16` | no |
+| <a name="input_instance_base_name"></a> [instance\_base\_name](#input\_instance\_base\_name) | MIG instance base names to use | `string` | `"daos-server"` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Set of key/value label pairs to assign to daos-server instances | `any` | `{}` | no |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | GCP machine type. ie. e2-medium | `string` | `"n2-custom-20-131072"` | no |
+| <a name="input_mig_name"></a> [mig\_name](#input\_mig\_name) | MIG name | `string` | `"daos-server"` | no |
+| <a name="input_network"></a> [network](#input\_network) | GCP network to use | `string` | n/a | yes |
+| <a name="input_number_of_instances"></a> [number\_of\_instances](#input\_number\_of\_instances) | Number of daos servers to bring up | `number` | `4` | no |
+| <a name="input_os_disk_size_gb"></a> [os\_disk\_size\_gb](#input\_os\_disk\_size\_gb) | OS disk size in GB | `number` | `20` | no |
+| <a name="input_os_disk_type"></a> [os\_disk\_type](#input\_os\_disk\_type) | OS disk type ie. pd-ssd, pd-standard | `string` | `"pd-ssd"` | no |
+| <a name="input_os_family"></a> [os\_family](#input\_os\_family) | OS GCP image family | `string` | `null` | no |
+| <a name="input_os_project"></a> [os\_project](#input\_os\_project) | OS GCP image project name | `string` | `null` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project to use | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | The GCP region to create and test resources in | `string` | n/a | yes |
+| <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | GCP sub-network to use | `string` | n/a | yes |
+| <a name="input_subnetwork_project"></a> [subnetwork\_project](#input\_subnetwork\_project) | The GCP project where the subnetwork is defined | `string` | n/a | yes |
+| <a name="input_template_name"></a> [template\_name](#input\_template\_name) | MIG template name | `string` | `"daos-server"` | no |
+| <a name="input_zone"></a> [zone](#input\_zone) | The GCP zone to create and test resources in | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/terraform/examples/simple_daos_server_example/main.tf
+++ b/terraform/examples/simple_daos_server_example/main.tf
@@ -26,6 +26,7 @@ module "daos_server" {
   subnetwork_project = var.subnetwork_project
   region             = var.region
   zone               = var.zone
+  labels             = var.labels
 
   number_of_instances = var.number_of_instances
   daos_disk_count     = var.daos_disk_count

--- a/terraform/examples/simple_daos_server_example/module.json
+++ b/terraform/examples/simple_daos_server_example/module.json
@@ -1,0 +1,146 @@
+{
+  "header": "Copyright 2021 Google LLC\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n     http://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.",
+  "footer": "",
+  "inputs": [
+    {
+      "name": "daos_disk_count",
+      "type": "number",
+      "description": "Number of local ssd's to use",
+      "default": 16,
+      "required": false
+    },
+    {
+      "name": "instance_base_name",
+      "type": "string",
+      "description": "MIG instance base names to use",
+      "default": "daos-server",
+      "required": false
+    },
+    {
+      "name": "labels",
+      "type": "any",
+      "description": "Set of key/value label pairs to assign to daos-server instances",
+      "default": {},
+      "required": false
+    },
+    {
+      "name": "machine_type",
+      "type": "string",
+      "description": "GCP machine type. ie. e2-medium",
+      "default": "n2-custom-20-131072",
+      "required": false
+    },
+    {
+      "name": "mig_name",
+      "type": "string",
+      "description": "MIG name ",
+      "default": "daos-server",
+      "required": false
+    },
+    {
+      "name": "network",
+      "type": "string",
+      "description": "GCP network to use",
+      "default": null,
+      "required": true
+    },
+    {
+      "name": "number_of_instances",
+      "type": "number",
+      "description": "Number of daos servers to bring up",
+      "default": 4,
+      "required": false
+    },
+    {
+      "name": "os_disk_size_gb",
+      "type": "number",
+      "description": "OS disk size in GB",
+      "default": 20,
+      "required": false
+    },
+    {
+      "name": "os_disk_type",
+      "type": "string",
+      "description": "OS disk type ie. pd-ssd, pd-standard",
+      "default": "pd-ssd",
+      "required": false
+    },
+    {
+      "name": "os_family",
+      "type": "string",
+      "description": "OS GCP image family",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "os_project",
+      "type": "string",
+      "description": "OS GCP image project name",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "project_id",
+      "type": "string",
+      "description": "The GCP project to use ",
+      "default": null,
+      "required": true
+    },
+    {
+      "name": "region",
+      "type": "string",
+      "description": "The GCP region to create and test resources in",
+      "default": null,
+      "required": true
+    },
+    {
+      "name": "subnetwork",
+      "type": "string",
+      "description": "GCP sub-network to use",
+      "default": null,
+      "required": true
+    },
+    {
+      "name": "subnetwork_project",
+      "type": "string",
+      "description": "The GCP project where the subnetwork is defined",
+      "default": null,
+      "required": true
+    },
+    {
+      "name": "template_name",
+      "type": "string",
+      "description": "MIG template name",
+      "default": "daos-server",
+      "required": false
+    },
+    {
+      "name": "zone",
+      "type": "string",
+      "description": "The GCP zone to create and test resources in",
+      "default": null,
+      "required": true
+    }
+  ],
+  "modules": [
+    {
+      "name": "daos_server",
+      "source": "../../modules/daos_server",
+      "version": "",
+      "description": null
+    }
+  ],
+  "outputs": [],
+  "providers": [],
+  "requirements": [
+    {
+      "name": "terraform",
+      "version": "\u003e= 0.14.5"
+    },
+    {
+      "name": "google",
+      "version": "\u003e= 3.54.0"
+    }
+  ],
+  "resources": []
+}

--- a/terraform/examples/simple_daos_server_example/terraform.tfvars.example
+++ b/terraform/examples/simple_daos_server_example/terraform.tfvars.example
@@ -1,9 +1,12 @@
-project_id="<my_project_id>"
+project_id = "<my_project_id>"
 network = "<my_VPC_network>"
 subnetwork = "<my_VPC_subnetwork>"
 subnetwork_project = "<my_project_id>"
 region = "europe-west4"
 zone = "europe-west4-a"
+labels = {
+  example="simple_daos_server_example"
+}
 
 number_of_instances = 4 # Allow 3-way replication with extra spare for rebuild
 daos_disk_count = 16

--- a/terraform/examples/simple_daos_server_example/variables.tf
+++ b/terraform/examples/simple_daos_server_example/variables.tf
@@ -27,6 +27,12 @@ variable "zone" {
   type        = string
 }
 
+variable "labels" {
+  description = "Set of key/value label pairs to assign to daos-server instances"
+  type        = any
+  default     = {}
+}
+
 variable "os_family" {
   description = "OS GCP image family"
   default     = null

--- a/terraform/examples/simple_daos_server_example/variables.tf
+++ b/terraform/examples/simple_daos_server_example/variables.tf
@@ -36,11 +36,13 @@ variable "labels" {
 variable "os_family" {
   description = "OS GCP image family"
   default     = null
+  type        = string
 }
 
 variable "os_project" {
   description = "OS GCP image project name"
   default     = null
+  type        = string
 }
 
 variable "os_disk_size_gb" {

--- a/terraform/examples/simple_daos_server_example/versions.tf
+++ b/terraform/examples/simple_daos_server_example/versions.tf
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+terraform {
+  required_version = ">= 0.14.5"
+  required_providers {
+    google = ">= 3.54.0"
+  }
+}

--- a/terraform/modules/daos_client/README.md
+++ b/terraform/modules/daos_client/README.md
@@ -40,6 +40,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_daos_service_account_scopes"></a> [daos\_service\_account\_scopes](#input\_daos\_service\_account\_scopes) | Scopes for the DAOS client service account | `list(string)` | <pre>[<br>  "userinfo-email",<br>  "compute-ro",<br>  "storage-ro"<br>]</pre> | no |
 | <a name="input_instance_base_name"></a> [instance\_base\_name](#input\_instance\_base\_name) | MIG instance base names to use | `string` | `null` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Set of key/value label pairs to assign to daos-client instances | `any` | n/a | no |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | GCP machine type. ie. e2-medium | `string` | `null` | no |
 | <a name="input_mig_name"></a> [mig\_name](#input\_mig\_name) | MIG name | `string` | `null` | no |
 | <a name="input_network"></a> [network](#input\_network) | GCP network to use | `string` | `null` | no |

--- a/terraform/modules/daos_client/README.md
+++ b/terraform/modules/daos_client/README.md
@@ -59,3 +59,72 @@ No modules.
 ## Outputs
 
 No outputs.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2021 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.5 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.54.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.54.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_instance_group_manager.daos_sig](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_group_manager) | resource |
+| [google_compute_instance_template.daos_sig_template](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_template) | resource |
+| [google_compute_per_instance_config.named_instances](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_per_instance_config) | resource |
+| [google_compute_image.os_image](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_daos_service_account_scopes"></a> [daos\_service\_account\_scopes](#input\_daos\_service\_account\_scopes) | Scopes for the DAOS client service account | `list(string)` | <pre>[<br>  "userinfo-email",<br>  "compute-ro",<br>  "storage-ro"<br>]</pre> | no |
+| <a name="input_instance_base_name"></a> [instance\_base\_name](#input\_instance\_base\_name) | MIG instance base names to use | `string` | `null` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Set of key/value label pairs to assign to daos-client instances | `any` | `{}` | no |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | GCP machine type. ie. e2-medium | `string` | `null` | no |
+| <a name="input_mig_name"></a> [mig\_name](#input\_mig\_name) | MIG name | `string` | `null` | no |
+| <a name="input_network"></a> [network](#input\_network) | GCP network to use | `string` | `null` | no |
+| <a name="input_number_of_instances"></a> [number\_of\_instances](#input\_number\_of\_instances) | Number of daos clients to bring up | `number` | `null` | no |
+| <a name="input_os_disk_size_gb"></a> [os\_disk\_size\_gb](#input\_os\_disk\_size\_gb) | OS disk size in GB | `number` | `20` | no |
+| <a name="input_os_disk_type"></a> [os\_disk\_type](#input\_os\_disk\_type) | OS disk type ie. pd-ssd, pd-standard | `string` | `"pd-ssd"` | no |
+| <a name="input_os_family"></a> [os\_family](#input\_os\_family) | OS GCP image family | `string` | `null` | no |
+| <a name="input_os_project"></a> [os\_project](#input\_os\_project) | OS GCP image project name | `string` | `null` | no |
+| <a name="input_preemptible"></a> [preemptible](#input\_preemptible) | If preemptible instances | `string` | `false` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project to use | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | The GCP region to create and test resources in | `string` | `null` | no |
+| <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | GCP sub-network to use | `string` | `null` | no |
+| <a name="input_subnetwork_project"></a> [subnetwork\_project](#input\_subnetwork\_project) | The GCP project where the subnetwork is defined | `string` | `null` | no |
+| <a name="input_template_name"></a> [template\_name](#input\_template\_name) | MIG template name | `string` | `null` | no |
+| <a name="input_zone"></a> [zone](#input\_zone) | The GCP zone to create and test resources in | `string` | `null` | no |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/terraform/modules/daos_client/main.tf
+++ b/terraform/modules/daos_client/main.tf
@@ -26,6 +26,7 @@ resource "google_compute_instance_template" "daos_sig_template" {
   tags           = ["daos-client"]
   project        = var.project_id
   region         = var.region
+  labels         = var.labels
 
   disk {
     source_image = data.google_compute_image.os_image.self_link

--- a/terraform/modules/daos_client/main.tf
+++ b/terraform/modules/daos_client/main.tf
@@ -47,7 +47,7 @@ resource "google_compute_instance_template" "daos_sig_template" {
   }
 
   scheduling {
-    preemptible = var.preemptible
+    preemptible       = var.preemptible
     automatic_restart = false
   }
 }
@@ -76,9 +76,9 @@ resource "google_compute_per_instance_config" "named_instances" {
     metadata = {
       inst_type      = "daos-client"
       enable-oslogin = "true"
-      // Adding a reference to the instance template used causes the stateful instance to update
-      // if the instance template changes. Otherwise there is no explicit dependency and template
-      // changes may not occur on the stateful instance
+      # Adding a reference to the instance template used causes the stateful instance to update
+      # if the instance template changes. Otherwise there is no explicit dependency and template
+      # changes may not occur on the stateful instance
       instance_template = google_compute_instance_template.daos_sig_template.self_link
     }
   }

--- a/terraform/modules/daos_client/module.json
+++ b/terraform/modules/daos_client/module.json
@@ -1,0 +1,193 @@
+{
+  "header": "Copyright 2021 Google LLC\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n     http://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.",
+  "footer": "",
+  "inputs": [
+    {
+      "name": "daos_service_account_scopes",
+      "type": "list(string)",
+      "description": "Scopes for the DAOS client service account",
+      "default": [
+        "userinfo-email",
+        "compute-ro",
+        "storage-ro"
+      ],
+      "required": false
+    },
+    {
+      "name": "instance_base_name",
+      "type": "string",
+      "description": "MIG instance base names to use",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "labels",
+      "type": "any",
+      "description": "Set of key/value label pairs to assign to daos-client instances",
+      "default": {},
+      "required": false
+    },
+    {
+      "name": "machine_type",
+      "type": "string",
+      "description": "GCP machine type. ie. e2-medium",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "mig_name",
+      "type": "string",
+      "description": "MIG name ",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "network",
+      "type": "string",
+      "description": "GCP network to use",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "number_of_instances",
+      "type": "number",
+      "description": "Number of daos clients to bring up",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "os_disk_size_gb",
+      "type": "number",
+      "description": "OS disk size in GB",
+      "default": 20,
+      "required": false
+    },
+    {
+      "name": "os_disk_type",
+      "type": "string",
+      "description": "OS disk type ie. pd-ssd, pd-standard",
+      "default": "pd-ssd",
+      "required": false
+    },
+    {
+      "name": "os_family",
+      "type": "string",
+      "description": "OS GCP image family",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "os_project",
+      "type": "string",
+      "description": "OS GCP image project name",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "preemptible",
+      "type": "string",
+      "description": "If preemptible instances",
+      "default": false,
+      "required": false
+    },
+    {
+      "name": "project_id",
+      "type": "string",
+      "description": "The GCP project to use ",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "region",
+      "type": "string",
+      "description": "The GCP region to create and test resources in",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "subnetwork",
+      "type": "string",
+      "description": "GCP sub-network to use",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "subnetwork_project",
+      "type": "string",
+      "description": "The GCP project where the subnetwork is defined",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "template_name",
+      "type": "string",
+      "description": "MIG template name",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "zone",
+      "type": "string",
+      "description": "The GCP zone to create and test resources in",
+      "default": null,
+      "required": false
+    }
+  ],
+  "modules": [],
+  "outputs": [],
+  "providers": [
+    {
+      "name": "google",
+      "alias": null,
+      "version": "\u003e= 3.54.0"
+    }
+  ],
+  "requirements": [
+    {
+      "name": "terraform",
+      "version": "\u003e= 0.14.5"
+    },
+    {
+      "name": "google",
+      "version": "\u003e= 3.54.0"
+    }
+  ],
+  "resources": [
+    {
+      "type": "compute_instance_group_manager",
+      "name": "daos_sig",
+      "provider": "google",
+      "source": "hashicorp/google",
+      "mode": "managed",
+      "version": "latest",
+      "description": null
+    },
+    {
+      "type": "compute_instance_template",
+      "name": "daos_sig_template",
+      "provider": "google",
+      "source": "hashicorp/google",
+      "mode": "managed",
+      "version": "latest",
+      "description": null
+    },
+    {
+      "type": "compute_per_instance_config",
+      "name": "named_instances",
+      "provider": "google",
+      "source": "hashicorp/google",
+      "mode": "managed",
+      "version": "latest",
+      "description": null
+    },
+    {
+      "type": "compute_image",
+      "name": "os_image",
+      "provider": "google",
+      "source": "hashicorp/google",
+      "mode": "data",
+      "version": "latest",
+      "description": null
+    }
+  ]
+}

--- a/terraform/modules/daos_client/variables.tf
+++ b/terraform/modules/daos_client/variables.tf
@@ -29,6 +29,12 @@ variable "zone" {
   default     = null
 }
 
+variable "labels" {
+  description = "Set of key/value label pairs to assign to daos-client instances"
+  type        = any
+  default     = {}
+}
+
 variable "os_family" {
   description = "OS GCP image family"
   default     = null

--- a/terraform/modules/daos_client/variables.tf
+++ b/terraform/modules/daos_client/variables.tf
@@ -119,6 +119,6 @@ variable "daos_service_account_scopes" {
 
 variable "preemptible" {
   description = "If preemptible instances"
-  default = false
-  type = string
+  default     = false
+  type        = string
 }

--- a/terraform/modules/daos_server/README.md
+++ b/terraform/modules/daos_server/README.md
@@ -39,6 +39,7 @@ The resources/services/activations/deletions that this module will create/trigge
 | <a name="input_daos_disk_type"></a> [daos\_disk\_type](#input\_daos\_disk\_type) | Daos disk type to use. For now only suported one is local-ssd | `string` | `"local-ssd"` | no |
 | <a name="input_daos_service_account_scopes"></a> [daos\_service\_account\_scopes](#input\_daos\_service\_account\_scopes) | Scopes for the DAOS server service account | `list(string)` | <pre>[<br>  "userinfo-email",<br>  "compute-ro",<br>  "storage-ro"<br>]</pre> | no |
 | <a name="input_instance_base_name"></a> [instance\_base\_name](#input\_instance\_base\_name) | MIG instance base names to use | `string` | `"daos-server"` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Set of key/value label pairs to assign to daos-server instances | `any` | n/a | no |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | GCP machine type. ie. e2-medium | `string` | `"n2-custom-20-131072"` | no |
 | <a name="input_mig_name"></a> [mig\_name](#input\_mig\_name) | MIG name | `string` | `"daos-server"` | no |
 | <a name="input_network"></a> [network](#input\_network) | GCP network to use | `string` | n/a | yes |

--- a/terraform/modules/daos_server/README.md
+++ b/terraform/modules/daos_server/README.md
@@ -58,3 +58,74 @@ The resources/services/activations/deletions that this module will create/trigge
 ## Outputs
 
 No outputs.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2021 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.5 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.54.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.54.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_instance_group_manager.daos_sig](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_group_manager) | resource |
+| [google_compute_instance_template.daos_sig_template](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_template) | resource |
+| [google_compute_per_instance_config.named_instances](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_per_instance_config) | resource |
+| [google_compute_image.os_image](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_daos_disk_count"></a> [daos\_disk\_count](#input\_daos\_disk\_count) | Number of local ssd's to use | `number` | `null` | no |
+| <a name="input_daos_disk_type"></a> [daos\_disk\_type](#input\_daos\_disk\_type) | Daos disk type to use. For now only suported one is local-ssd | `string` | `"local-ssd"` | no |
+| <a name="input_daos_service_account_scopes"></a> [daos\_service\_account\_scopes](#input\_daos\_service\_account\_scopes) | Scopes for the DAOS server service account | `list(string)` | <pre>[<br>  "userinfo-email",<br>  "compute-ro",<br>  "storage-ro"<br>]</pre> | no |
+| <a name="input_instance_base_name"></a> [instance\_base\_name](#input\_instance\_base\_name) | MIG instance base names to use | `string` | `null` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Set of key/value label pairs to assign to daos-server instances | `any` | `{}` | no |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | GCP machine type. ie. e2-medium | `string` | `null` | no |
+| <a name="input_mig_name"></a> [mig\_name](#input\_mig\_name) | MIG name | `string` | `null` | no |
+| <a name="input_network"></a> [network](#input\_network) | GCP network to use | `string` | `null` | no |
+| <a name="input_number_of_instances"></a> [number\_of\_instances](#input\_number\_of\_instances) | Number of daos servers to bring up | `number` | `null` | no |
+| <a name="input_os_disk_size_gb"></a> [os\_disk\_size\_gb](#input\_os\_disk\_size\_gb) | OS disk size in GB | `number` | `20` | no |
+| <a name="input_os_disk_type"></a> [os\_disk\_type](#input\_os\_disk\_type) | OS disk type ie. pd-ssd, pd-standard | `string` | `"pd-ssd"` | no |
+| <a name="input_os_family"></a> [os\_family](#input\_os\_family) | OS GCP image family | `string` | `null` | no |
+| <a name="input_os_project"></a> [os\_project](#input\_os\_project) | OS GCP image project name | `string` | `null` | no |
+| <a name="input_preemptible"></a> [preemptible](#input\_preemptible) | If preemptible instances | `string` | `false` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project to use | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | The GCP region to create and test resources in | `string` | `null` | no |
+| <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | GCP sub-network to use | `string` | `null` | no |
+| <a name="input_subnetwork_project"></a> [subnetwork\_project](#input\_subnetwork\_project) | The GCP project where the subnetwork is defined | `string` | `null` | no |
+| <a name="input_template_name"></a> [template\_name](#input\_template\_name) | MIG template name | `string` | `null` | no |
+| <a name="input_zone"></a> [zone](#input\_zone) | The GCP zone to create and test resources in | `string` | `null` | no |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/terraform/modules/daos_server/main.tf
+++ b/terraform/modules/daos_server/main.tf
@@ -58,7 +58,7 @@ resource "google_compute_instance_template" "daos_sig_template" {
   }
 
   scheduling {
-    preemptible = var.preemptible
+    preemptible       = var.preemptible
     automatic_restart = false
   }
 }
@@ -89,9 +89,9 @@ resource "google_compute_per_instance_config" "named_instances" {
       enable-oslogin = "true"
       inst_nr        = var.number_of_instances
       inst_base_name = var.instance_base_name
-      // Adding a reference to the instance template used causes the stateful instance to update
-      // if the instance template changes. Otherwise there is no explicit dependency and template
-      // changes may not occur on the stateful instance
+      # Adding a reference to the instance template used causes the stateful instance to update
+      # if the instance template changes. Otherwise there is no explicit dependency and template
+      # changes may not occur on the stateful instance
       instance_template = google_compute_instance_template.daos_sig_template.self_link
     }
   }

--- a/terraform/modules/daos_server/main.tf
+++ b/terraform/modules/daos_server/main.tf
@@ -26,6 +26,7 @@ resource "google_compute_instance_template" "daos_sig_template" {
   tags           = ["daos-server"]
   project        = var.project_id
   region         = var.region
+  labels         = var.labels
 
   disk {
     source_image = data.google_compute_image.os_image.self_link

--- a/terraform/modules/daos_server/module.json
+++ b/terraform/modules/daos_server/module.json
@@ -1,0 +1,207 @@
+{
+  "header": "Copyright 2021 Google LLC\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n     http://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.",
+  "footer": "",
+  "inputs": [
+    {
+      "name": "daos_disk_count",
+      "type": "number",
+      "description": "Number of local ssd's to use",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "daos_disk_type",
+      "type": "string",
+      "description": "Daos disk type to use. For now only suported one is local-ssd",
+      "default": "local-ssd",
+      "required": false
+    },
+    {
+      "name": "daos_service_account_scopes",
+      "type": "list(string)",
+      "description": "Scopes for the DAOS server service account",
+      "default": [
+        "userinfo-email",
+        "compute-ro",
+        "storage-ro"
+      ],
+      "required": false
+    },
+    {
+      "name": "instance_base_name",
+      "type": "string",
+      "description": "MIG instance base names to use",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "labels",
+      "type": "any",
+      "description": "Set of key/value label pairs to assign to daos-server instances",
+      "default": {},
+      "required": false
+    },
+    {
+      "name": "machine_type",
+      "type": "string",
+      "description": "GCP machine type. ie. e2-medium",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "mig_name",
+      "type": "string",
+      "description": "MIG name ",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "network",
+      "type": "string",
+      "description": "GCP network to use",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "number_of_instances",
+      "type": "number",
+      "description": "Number of daos servers to bring up",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "os_disk_size_gb",
+      "type": "number",
+      "description": "OS disk size in GB",
+      "default": 20,
+      "required": false
+    },
+    {
+      "name": "os_disk_type",
+      "type": "string",
+      "description": "OS disk type ie. pd-ssd, pd-standard",
+      "default": "pd-ssd",
+      "required": false
+    },
+    {
+      "name": "os_family",
+      "type": "string",
+      "description": "OS GCP image family",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "os_project",
+      "type": "string",
+      "description": "OS GCP image project name",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "preemptible",
+      "type": "string",
+      "description": "If preemptible instances",
+      "default": false,
+      "required": false
+    },
+    {
+      "name": "project_id",
+      "type": "string",
+      "description": "The GCP project to use ",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "region",
+      "type": "string",
+      "description": "The GCP region to create and test resources in",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "subnetwork",
+      "type": "string",
+      "description": "GCP sub-network to use",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "subnetwork_project",
+      "type": "string",
+      "description": "The GCP project where the subnetwork is defined",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "template_name",
+      "type": "string",
+      "description": "MIG template name",
+      "default": null,
+      "required": false
+    },
+    {
+      "name": "zone",
+      "type": "string",
+      "description": "The GCP zone to create and test resources in",
+      "default": null,
+      "required": false
+    }
+  ],
+  "modules": [],
+  "outputs": [],
+  "providers": [
+    {
+      "name": "google",
+      "alias": null,
+      "version": "\u003e= 3.54.0"
+    }
+  ],
+  "requirements": [
+    {
+      "name": "terraform",
+      "version": "\u003e= 0.14.5"
+    },
+    {
+      "name": "google",
+      "version": "\u003e= 3.54.0"
+    }
+  ],
+  "resources": [
+    {
+      "type": "compute_instance_group_manager",
+      "name": "daos_sig",
+      "provider": "google",
+      "source": "hashicorp/google",
+      "mode": "managed",
+      "version": "latest",
+      "description": null
+    },
+    {
+      "type": "compute_instance_template",
+      "name": "daos_sig_template",
+      "provider": "google",
+      "source": "hashicorp/google",
+      "mode": "managed",
+      "version": "latest",
+      "description": null
+    },
+    {
+      "type": "compute_per_instance_config",
+      "name": "named_instances",
+      "provider": "google",
+      "source": "hashicorp/google",
+      "mode": "managed",
+      "version": "latest",
+      "description": null
+    },
+    {
+      "type": "compute_image",
+      "name": "os_image",
+      "provider": "google",
+      "source": "hashicorp/google",
+      "mode": "data",
+      "version": "latest",
+      "description": null
+    }
+  ]
+}

--- a/terraform/modules/daos_server/variables.tf
+++ b/terraform/modules/daos_server/variables.tf
@@ -133,6 +133,6 @@ variable "daos_service_account_scopes" {
 
 variable "preemptible" {
   description = "If preemptible instances"
-  default = false
-  type = string
+  default     = false
+  type        = string
 }

--- a/terraform/modules/daos_server/variables.tf
+++ b/terraform/modules/daos_server/variables.tf
@@ -29,6 +29,12 @@ variable "zone" {
   default     = null
 }
 
+variable "labels" {
+  description = "Set of key/value label pairs to assign to daos-server instances"
+  type        = any
+  default     = {}
+}
+
 variable "os_family" {
   description = "OS GCP image family"
   default     = null

--- a/tools/autodoc/terraform_docs.sh
+++ b/tools/autodoc/terraform_docs.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+index=0
+declare -a paths
+for file in "$@"; do
+    paths[index]=$(dirname $file)
+    ((index += 1))
+done
+
+uniq_paths=$(echo "${paths[@]}" | tr ' ' '\n' | sort -u)
+
+for path in $uniq_paths; do
+    terraform-docs markdown --config .tfdocs-markdown.yaml ${path}
+    terraform-docs json --config .tfdocs-json.yaml ${path}
+done


### PR DESCRIPTION
Added configuration files for

- pre-commit 
- tflint
- tfdocs

Added tools/autodoc/terraform_docs.sh which is also used in HPC Toolkit to auto generate documentation in README.md for terraform modules.

Added docs/development.md which contains information about installing pre-commit and dependencies and how to install the pre-commit hooks.

Added link to docs/development.md  on the main readme