### PR TITLE
DAOSGCP-100 Added pre-commit hook for addlicense

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ id_rsa*
 hosts*
 *.flag
 keys.txt
+
+# addlicense binary for pre-commit
+tools/autodoc/addlicense

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,30 @@
+# Copyright 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 repos:
+  - repo: local
+    hooks:
+      - id: addlicense
+        name: addlicense
+        entry: tools/autodoc/addlicense.sh
+        language: script
+        types: ['text']
+        exclude: ^(\.terraform\/.*$|\..*|README.md)
+        exclude_types: ['json']
+        pass_filenames: true
+        require_serial: true
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.64.0
     hooks:
@@ -16,12 +41,5 @@ repos:
         language: script
         types: ['terraform']
         exclude: \.terraform\/.*$
-        pass_filenames: true
-        require_serial: true
-      - id: packer-readme
-        name: packer-readme
-        entry: tools/autodoc/terraform_docs.sh
-        language: script
-        files: ^.*\.pkr\.hcl$
         pass_filenames: true
         require_serial: true

--- a/docs/development.md
+++ b/docs/development.md
@@ -15,7 +15,6 @@ You will also need to install the dependencies that are required for the pre-com
 
    Instructions can be found at the [pre-commit website](https://pre-commit.com/#install).
 
-
 2. Install [TFLint](https://github.com/terraform-linters/tflint)
 
    See the [installation instructions](https://github.com/terraform-linters/tflint#installation)
@@ -31,8 +30,23 @@ You will also need to install the dependencies that are required for the pre-com
 
    See [https://github.com/terraform-docs/terraform-docs](https://github.com/terraform-docs/terraform-docs)
 
+4. Add `ADDLICENSE_COMPANY_NAME` environment variable to your `~/.bashrc` file
 
-4. MacOS only
+   When pre-commit runs for the first time it will download the [google/addlicense](https://github.com/google/addlicense/releases/tag/v1.0.0) binary into the `tools/autodoc/` directory. The `addlicense` binary is excluded in the `.gitignore` file so it does not get checked into the repo.
+
+   The `addlicense` pre-commit hook will ensure that files have the proper license header.
+
+   The company name that is used in the license header is specified in the `ADDLICENSE_COMPANY_NAME` environment variable.
+
+   If the `ADDLICENSE_COMPANY_NAME` environment variable is not present, the company name in the license header will be set to **Intel Corporation**
+
+   If you do not work for Intel be sure to export the `ADDLICENSE_COMPANY_NAME` environment variable with the name of your company as it should appear in the license header of files.
+
+   ```bash
+   export ADDLICENSE_COMPANY_NAME="your_company_name_here"
+   ```
+
+5. MacOS only
 
    MacOS users will need to install `findutils` and `coreutils`.
 

--- a/images/build_images.sh
+++ b/images/build_images.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #
 # Build DAOS server and client images using Packer in Google Cloud Build
 #

--- a/images/daos-client-image.pkr.hcl
+++ b/images/daos-client-image.pkr.hcl
@@ -1,3 +1,17 @@
+// Copyright 2022 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 packer {
   required_plugins {
     googlecompute = {

--- a/images/daos-server-image.pkr.hcl
+++ b/images/daos-server-image.pkr.hcl
@@ -1,3 +1,17 @@
+// Copyright 2022 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 packer {
   required_plugins {
     googlecompute = {

--- a/images/daos_version.sh
+++ b/images/daos_version.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 # Default DAOS version to be installed in images
 export DEFAULT_DAOS_VERSION="2.0"

--- a/images/scripts/install_daos.sh
+++ b/images/scripts/install_daos.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #
 # Install DAOS Server or Client packages
 #
@@ -180,8 +194,7 @@ add_repo() {
   esac
 
   echo "Adding DAOS v${DAOS_VERSION} packages repo"
-  curl -s --output /etc/yum.repos.d/daos_packages.repo "https://packages.daos.io/v${DAOS_VERSION}/${DAOS_OS_VERSION}/packages/x86_64/daos_packages.repo"
-
+  curl -s -k --output /etc/yum.repos.d/daos_packages.repo "https://packages.daos.io/v${DAOS_VERSION}/${DAOS_OS_VERSION}/packages/x86_64/daos_packages.repo"
 }
 
 install_epel() {
@@ -192,6 +205,10 @@ install_epel() {
 }
 
 install_daos() {
+  if [ ! -f $(which wget) ];then
+    yum -y install wget
+  fi
+
   if [[ "${DAOS_INSTALL_TYPE,,}" =~ ^(all|client)$ ]]; then
     echo "Install daos-client and daos-devel packages"
     yum install -y daos-client daos-devel
@@ -205,7 +222,6 @@ install_daos() {
   if echo "${DAOS_VERSION}" | grep -q -e '^1\..*'; then
     # Upgrade SPDK to work around the GCP NVMe bug with number of qpairs
     # in DAOS v1.2
-    yum install -y wget
     TMP_DIR="$(mktemp -d)"
     pushd .
     cd "${TMP_DIR}"
@@ -222,7 +238,7 @@ downgrade_libfabric() {
     wget https://packages.daos.io/v1.2/CentOS7/packages/x86_64/libfabric-1.12.0-1.el7.x86_64.rpm
     rpm -i --force ./libfabric-1.12.0-1.el7.x86_64.rpm
     rpm --erase --nodeps  libfabric-1.14.0
-    echo "exclude=libfabric" >> /etc/yum.repos.d/daos.repo
+    echo "exclude=libfabric" >> /etc/yum.repos.d/daos_packages.repo
     rm -f ./libfabric-1.12.0-1.el7.x86_64.rpm
   fi
 }

--- a/terraform/examples/daos_cluster/README.md
+++ b/terraform/examples/daos_cluster/README.md
@@ -207,6 +207,20 @@ This will shut down all DAOS server and client instances.
 # Terraform Documentation for this Example
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2022 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 ## Requirements
 
 | Name | Version |

--- a/terraform/examples/daos_cluster/main.tf
+++ b/terraform/examples/daos_cluster/main.tf
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 provider "google" {
   region = var.region
 }

--- a/terraform/examples/daos_cluster/module.json
+++ b/terraform/examples/daos_cluster/module.json
@@ -1,5 +1,5 @@
 {
-  "header": "",
+  "header": "Copyright 2022 Intel Corporation\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n     http://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.",
   "footer": "",
   "inputs": [
     {

--- a/terraform/examples/daos_cluster/variables.tf
+++ b/terraform/examples/daos_cluster/variables.tf
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 variable "project_id" {
   description = "The GCP project to use "
   type        = string

--- a/terraform/examples/daos_cluster/versions.tf
+++ b/terraform/examples/daos_cluster/versions.tf
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 terraform {
   required_version = ">= 0.14.5"
   required_providers {

--- a/terraform/examples/io500/build_daos_io500_images.sh
+++ b/terraform/examples/io500/build_daos_io500_images.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #
 # Build daos-server and daos-client images.
 # The daos-client image will have IO500 pre-installed.

--- a/terraform/examples/io500/clean_storage.sh
+++ b/terraform/examples/io500/clean_storage.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #
 # Clean storage on DAOS servers
 #

--- a/terraform/examples/io500/config/config.sh
+++ b/terraform/examples/io500/config/config.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 # ------------------------------------------------------------------------------
 # Configure the following variables to meet your specific needs

--- a/terraform/examples/io500/config/config_1c_1s_8d.sh
+++ b/terraform/examples/io500/config/config_1c_1s_8d.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 # ------------------------------------------------------------------------------
 # Configuration: 1 client, 1 server with 8 disks

--- a/terraform/examples/io500/config/config_2c_2s_16d.sh
+++ b/terraform/examples/io500/config/config_2c_2s_16d.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 # ------------------------------------------------------------------------------
 # Configuration: 2 clients, 2 servers each with 16 disks

--- a/terraform/examples/io500/configure_daos.sh
+++ b/terraform/examples/io500/configure_daos.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #
 # Configures the /etc/daos/daos_*.yml files on daos-server and daos-client
 # instances.

--- a/terraform/examples/io500/install_scripts/install_devtools.sh
+++ b/terraform/examples/io500/install_scripts/install_devtools.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #
 # Install development tools and other packages needed for IO500
 #

--- a/terraform/examples/io500/install_scripts/install_intel-oneapi.sh
+++ b/terraform/examples/io500/install_scripts/install_intel-oneapi.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #
 # Install Intel OneAPI
 #

--- a/terraform/examples/io500/install_scripts/install_io500-sc21.sh
+++ b/terraform/examples/io500/install_scripts/install_io500-sc21.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #
 # Install IO500 SC21
 #

--- a/terraform/examples/io500/install_scripts/install_mpifileutils.sh
+++ b/terraform/examples/io500/install_scripts/install_mpifileutils.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #
 # Install mpifileutils
 #

--- a/terraform/examples/io500/run_io500-sc21.sh
+++ b/terraform/examples/io500/run_io500-sc21.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #
 # Cleans DAOS storage and runs an IO500 benchmark
 #

--- a/terraform/examples/io500/start.sh
+++ b/terraform/examples/io500/start.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #
 # Runs Terraform to create DAOS Server and Client instances.
 # Copies necessary files to clients to allow the IO500 benchmark to be run.

--- a/terraform/examples/io500/stop.sh
+++ b/terraform/examples/io500/stop.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 set -e
 trap 'echo "Hit an unexpected and unchecked error. Exiting."' ERR

--- a/terraform/examples/only_daos_client/README.md
+++ b/terraform/examples/only_daos_client/README.md
@@ -86,6 +86,20 @@ terraform destroy
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2022 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 ## Requirements
 
 | Name | Version |

--- a/terraform/examples/only_daos_client/main.tf
+++ b/terraform/examples/only_daos_client/main.tf
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 provider "google" {
   region = var.region
 }

--- a/terraform/examples/only_daos_client/module.json
+++ b/terraform/examples/only_daos_client/module.json
@@ -1,5 +1,5 @@
 {
-  "header": "",
+  "header": "Copyright 2022 Intel Corporation\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n     http://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.",
   "footer": "",
   "inputs": [
     {

--- a/terraform/examples/only_daos_client/versions.tf
+++ b/terraform/examples/only_daos_client/versions.tf
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 terraform {
   required_version = ">= 0.14.5"
   required_providers {

--- a/terraform/examples/only_daos_server/README.md
+++ b/terraform/examples/only_daos_server/README.md
@@ -100,6 +100,20 @@ terraform destroy
 # Terraform Documentation for this Example
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2022 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 ## Requirements
 
 | Name | Version |

--- a/terraform/examples/only_daos_server/main.tf
+++ b/terraform/examples/only_daos_server/main.tf
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 provider "google" {
   region = var.region
 }

--- a/terraform/examples/only_daos_server/module.json
+++ b/terraform/examples/only_daos_server/module.json
@@ -1,5 +1,5 @@
 {
-  "header": "",
+  "header": "Copyright 2022 Intel Corporation\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n     http://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.",
   "footer": "",
   "inputs": [
     {

--- a/terraform/examples/only_daos_server/variables.tf
+++ b/terraform/examples/only_daos_server/variables.tf
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 variable "project_id" {
   description = "The GCP project to use "
   type        = string

--- a/terraform/examples/only_daos_server/versions.tf
+++ b/terraform/examples/only_daos_server/versions.tf
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 terraform {
   required_version = ">= 0.14.5"
   required_providers {

--- a/terraform/modules/daos_server/outputs.tf
+++ b/terraform/modules/daos_server/outputs.tf
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 
 output "access_points" {
   description = "List of DAOS servers to use as access points"

--- a/terraform/modules/daos_server/scripts/daos_client_install_script.sh
+++ b/terraform/modules/daos_server/scripts/daos_client_install_script.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Install DAOS Client package
 #
 # TODO: Add support for installing on openSUSE Leap 15.3 and Ubuntu 20.04 LTS

--- a/tools/autodoc/addlicense.sh
+++ b/tools/autodoc/addlicense.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Copyright 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+ADDLICENSE_VERSION="1.0.0"
+ADDLICENSE_TAG_URL="https://github.com/google/addlicense/releases/download/v${ADDLICENSE_VERSION}"
+
+ADDLICENSE_COMPANY_NAME="${ADDLICENSE_COMPANY_NAME:-Intel Corporation}"
+
+pushd () {
+    command pushd "$@" > /dev/null
+}
+
+popd () {
+    command popd "$@" > /dev/null
+}
+
+download_addlicense() {
+	case $(uname | tr '[:upper:]' '[:lower:]') in
+		linux*)
+		  ADDLICENSE_ARCHIVE="addlicense_${ADDLICENSE_VERSION}_Linux_${HOSTTYPE}.tar.gz"
+			;;
+		darwin*)
+			ADDLICENSE_ARCHIVE="addlicense_${ADDLICENSE_VERSION}_macOS_${HOSTTYPE}.tar.gz"
+			;;
+		*)
+			echo "Unsupported OS!"
+			exit 1
+	esac
+	echo "Downloading ${ADDLICENSE_TAG_URL}/${ADDLICENSE_ARCHIVE}"
+	curl  -s -L -O "${ADDLICENSE_TAG_URL}/${ADDLICENSE_ARCHIVE}"
+	if [ -f "${SCRIPT_DIR}/${ADDLICENSE_ARCHIVE}" ]; then
+		tar -xzf "${ADDLICENSE_ARCHIVE}"
+		chmod +x addlicense
+		rm -f "${SCRIPT_DIR}/${ADDLICENSE_ARCHIVE}"
+	fi
+}
+
+pushd .
+cd "${SCRIPT_DIR}"
+
+if [ "$(which addlicense)" ]; then
+	ADDLICENSE_PATH="$(which addlicense)"
+else
+	if [ ! -f "${SCRIPT_DIR}/addlicense" ]; then
+		echo "Need to download the 'addlicense' binary"
+		download_addlicense
+	fi
+  ADDLICENSE_PATH="${SCRIPT_DIR}/addlicense"
+fi
+
+popd
+${ADDLICENSE_PATH} -c "${ADDLICENSE_COMPANY_NAME}" -l apache "$@"

--- a/tools/autodoc/addlicense.sh
+++ b/tools/autodoc/addlicense.sh
@@ -42,7 +42,7 @@ download_addlicense() {
 	echo "Downloading ${ADDLICENSE_TAG_URL}/${ADDLICENSE_ARCHIVE}"
 	curl  -s -L -O "${ADDLICENSE_TAG_URL}/${ADDLICENSE_ARCHIVE}"
 	if [ -f "${SCRIPT_DIR}/${ADDLICENSE_ARCHIVE}" ]; then
-		tar -xzf "${ADDLICENSE_ARCHIVE}"
+		tar -xz --file "${ADDLICENSE_ARCHIVE}" addlicense
 		chmod +x addlicense
 		rm -f "${SCRIPT_DIR}/${ADDLICENSE_ARCHIVE}"
 	fi

--- a/tools/autodoc/cloudshell_urls.sh
+++ b/tools/autodoc/cloudshell_urls.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #
 # File: cloudshell_urls.sh
 #
@@ -8,6 +22,7 @@
 #
 #     ./cloudshell_urls.sh main
 #
+
 set -e
 trap 'echo "Unexpected and unchecked error. Exiting."' ERR
 


### PR DESCRIPTION
Added pre-commit hook to run https://github.com/google/addlicense in order to ensure that a license header is added to files.

Signed-off-by: Mark A. Olson <mark.a.olson@intel.com>