### PR TITLE
DAOSGCP-102 Changed packer scripts to use IAP with private IP

### DIFF
--- a/images/build_images.sh
+++ b/images/build_images.sh
@@ -282,26 +282,19 @@ configure_gcp_project() {
       --role roles/iam.serviceAccountUser
   fi
 
-  FWRULENAME="gcp-cloudbuild-ssh"
-
-  # Check if we have an ssh firewall rule for cloudbuild in place already
-  FWLIST=$(gcloud compute --project="${GCP_PROJECT}" \
-    firewall-rules list \
-    --filter name="${FWRULENAME}" \
-    --sort-by priority \
-    --format='value(name)')
-
-  if [[ -z ${FWLIST} ]]; then
-    # Setup firewall rule to allow ssh from clould build.
-    # FIXME: Needs to be fixed to restric to IP range
-    # for clound build only once we know what that is.
-    log "Setting up firewall rule for ssh and clouldbuild"
-    gcloud compute --project="${GCP_PROJECT}" firewall-rules create "${FWRULENAME}" \
-    --direction=INGRESS --priority=1000 --network=default --action=ALLOW \
-    --rules=tcp:22 --source-ranges=0.0.0.0/0
-  else
-    log "Firewall rule for ssh and cloud build already in place."
+  CHECK_ROLE_SVC_ACCT=$(
+    gcloud projects get-iam-policy "${GCP_PROJECT}" \
+    --flatten="bindings[].members" \
+    --filter="bindings.role=roles/iap.tunnelResourceAccessor AND \
+              bindings.members=${CLOUD_BUILD_ACCOUNT}" \
+    --format="value(bindings.members[])"
+  )
+  if [[ "${CHECK_ROLE_SVC_ACCT}" != "${CLOUD_BUILD_ACCOUNT}" ]]; then
+    gcloud projects add-iam-policy-binding "${GCP_PROJECT}" \
+      --member "${CLOUD_BUILD_ACCOUNT}" \
+      --role roles/iap.tunnelResourceAccessor
   fi
+
 }
 
 build_images() {
@@ -321,10 +314,6 @@ build_images() {
   fi
 }
 
-remove_firewall() {
-  gcloud -q compute --project="${GCP_PROJECT}" firewall-rules delete "${FWRULENAME}"
-}
-
 list_images() {
   log "Image(s) created"
   gcloud compute images list \
@@ -340,7 +329,6 @@ main() {
   log_section "Building DAOS Image(s)"
   configure_gcp_project
   build_images
-  remove_firewall
   list_images
 }
 

--- a/images/build_images.sh
+++ b/images/build_images.sh
@@ -282,14 +282,14 @@ configure_gcp_project() {
       --role roles/iam.serviceAccountUser
   fi
 
-  CHECK_ROLE_SVC_ACCT=$(
+  CHECK_ROLE_IAP_TUNL_RESR_ACCS=$(
     gcloud projects get-iam-policy "${GCP_PROJECT}" \
     --flatten="bindings[].members" \
     --filter="bindings.role=roles/iap.tunnelResourceAccessor AND \
               bindings.members=${CLOUD_BUILD_ACCOUNT}" \
     --format="value(bindings.members[])"
   )
-  if [[ "${CHECK_ROLE_SVC_ACCT}" != "${CLOUD_BUILD_ACCOUNT}" ]]; then
+  if [[ "${CHECK_ROLE_IAP_TUNL_RESR_ACCS}" != "${CLOUD_BUILD_ACCOUNT}" ]]; then
     gcloud projects add-iam-policy-binding "${GCP_PROJECT}" \
       --member "${CLOUD_BUILD_ACCOUNT}" \
       --role roles/iap.tunnelResourceAccessor

--- a/images/daos-client-image.pkr.hcl
+++ b/images/daos-client-image.pkr.hcl
@@ -49,6 +49,10 @@ source "googlecompute" "daos-client-hpc-centos-7" {
   source_image_project_id = ["cloud-hpc-image-public"]
   ssh_username            = "packer"
   zone                    = "${var.zone}"
+  state_timeout           = "10m"
+  use_internal_ip         = true
+  omit_external_ip        = true
+  use_iap                 = true
 }
 
 build {

--- a/images/daos-server-image.pkr.hcl
+++ b/images/daos-server-image.pkr.hcl
@@ -49,6 +49,10 @@ source "googlecompute" "daos-server-centos-7" {
   source_image_project_id = ["centos-cloud"]
   ssh_username            = "packer"
   zone                    = "${var.zone}"
+  state_timeout           = "10m"
+  use_internal_ip         = true
+  omit_external_ip        = true
+  use_iap                 = true
 }
 
 build {


### PR DESCRIPTION
The images/build_images.sh script was setting up a firewall rule
to allow port 22 to 0.0.0.0/0.  Packer was then using SSH to
configure the image. Removed the firewall rule and changed packer
to only use an internal IP and then use IAP tunnelling to
log into the instance via SSH.

Signed-off-by: Mark A. Olson <mark.a.olson@intel.com>