### PR TITLE
DAOSGCP-103 Copy agent cert files on server instances

### DIFF
--- a/images/scripts/cert_gen/sm_get_ca.sh
+++ b/images/scripts/cert_gen/sm_get_ca.sh
@@ -151,7 +151,11 @@ if [[ "${INSTALL_TYPE,,}" == "server" ]]; then
   # So all certs and keys should be owned by root
   cp ${DAOS_DIR}/daosCA/certs/daosCA.crt /etc/daos/certs/
   cp ${DAOS_DIR}/daosCA/certs/server.* /etc/daos/certs/
+
   cp ${DAOS_DIR}/daosCA/certs/agent.* /etc/daos/certs/
+  chown daos_agent:daos_agent /etc/daos/certs/agent.*
+  chmod 0644 /etc/daos/certs/agent.crt
+  chmod 0600 /etc/daos/certs/agent.key
 
   # Server needs a copy of the agent.crt in /etc/daos/certs/clients
   mkdir -p /etc/daos/certs/clients

--- a/images/scripts/cert_gen/sm_get_ca.sh
+++ b/images/scripts/cert_gen/sm_get_ca.sh
@@ -151,6 +151,7 @@ if [[ "${INSTALL_TYPE,,}" == "server" ]]; then
   # So all certs and keys should be owned by root
   cp ${DAOS_DIR}/daosCA/certs/daosCA.crt /etc/daos/certs/
   cp ${DAOS_DIR}/daosCA/certs/server.* /etc/daos/certs/
+  cp ${DAOS_DIR}/daosCA/certs/agent.* /etc/daos/certs/
 
   # Server needs a copy of the agent.crt in /etc/daos/certs/clients
   mkdir -p /etc/daos/certs/clients


### PR DESCRIPTION
Copy the agent.crt and agent.key files to /etc/daos/certs
on DAOS server instances

Signed-off-by: Mark A. Olson <mark.a.olson@intel.com>