### PR TITLE
DAOSGCP-104 Fix image build issues related to IAP tunneling configuration

### DIFF
--- a/images/daos-client-image.pkr.hcl
+++ b/images/daos-client-image.pkr.hcl
@@ -51,7 +51,7 @@ source "googlecompute" "daos-client-hpc-centos-7" {
   zone                    = "${var.zone}"
   state_timeout           = "10m"
   use_internal_ip         = true
-  omit_external_ip        = true
+  omit_external_ip        = false
   use_iap                 = true
 }
 
@@ -77,8 +77,8 @@ build {
     inline = [
       "sudo mkdir -p /var/daos/cert_gen",
       "sudo mv /tmp/sm_get_ca.sh /var/daos/cert_gen",
-      "sudo chown -R root:root /var/daos/cert_gen",
-      "sudo chmod +x /var/daos/cert_gen/*.sh"
+      "sudo chmod +x /var/daos/cert_gen/*.sh",
+      "sudo chown -R root:root /var/daos/cert_gen"
     ]
   }
 

--- a/images/daos-server-image.pkr.hcl
+++ b/images/daos-server-image.pkr.hcl
@@ -51,7 +51,7 @@ source "googlecompute" "daos-server-centos-7" {
   zone                    = "${var.zone}"
   state_timeout           = "10m"
   use_internal_ip         = true
-  omit_external_ip        = true
+  omit_external_ip        = false
   use_iap                 = true
 }
 
@@ -77,8 +77,8 @@ build {
     inline = [
       "sudo mkdir -p /var/daos/",
       "sudo mv /tmp/cert_gen /var/daos/",
-      "sudo chown -R root:root /var/daos/cert_gen",
-      "sudo chmod +x /var/daos/cert_gen/*.sh"
+      "sudo chmod +x /var/daos/cert_gen/*.sh",
+      "sudo chown -R root:root /var/daos/cert_gen"
     ]
   }
 }


### PR DESCRIPTION
* Changing packer so the machine has a public IP addresses, which is
  necessary if the customer project does not have a cloud NAT.
* Changing the order of cert steps to increase reliability: chmod before
  chown.

Signed-off-by: Carlos Boneti <carlosboneti@google.com>