### PR TITLE
Fixing daos-client defaults.

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,6 +1,6 @@
 plugin "google" {
   enabled = true
-  version = "0.12.1"
+  version = "0.16.1"
   source  = "github.com/terraform-linters/tflint-ruleset-google"
 }
 rule "terraform_deprecated_index" {

--- a/terraform/modules/daos_client/README.md
+++ b/terraform/modules/daos_client/README.md
@@ -68,7 +68,7 @@ No modules.
 | <a name="input_number_of_instances"></a> [number\_of\_instances](#input\_number\_of\_instances) | Number of daos clients to bring up | `number` | `4` | no |
 | <a name="input_os_disk_size_gb"></a> [os\_disk\_size\_gb](#input\_os\_disk\_size\_gb) | OS disk size in GB | `number` | `20` | no |
 | <a name="input_os_disk_type"></a> [os\_disk\_type](#input\_os\_disk\_type) | OS disk type ie. pd-ssd, pd-standard | `string` | `"pd-ssd"` | no |
-| <a name="input_os_family"></a> [os\_family](#input\_os\_family) | OS GCP image family | `string` | `"daos-client-centos-7"` | no |
+| <a name="input_os_family"></a> [os\_family](#input\_os\_family) | OS GCP image family | `string` | `"daos-client-hpc-centos-7"` | no |
 | <a name="input_os_project"></a> [os\_project](#input\_os\_project) | OS GCP image project name. Defaults to project\_id if null. | `string` | `null` | no |
 | <a name="input_preemptible"></a> [preemptible](#input\_preemptible) | If preemptible instances | `string` | `false` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project to use | `string` | n/a | yes |

--- a/terraform/modules/daos_client/module.json
+++ b/terraform/modules/daos_client/module.json
@@ -97,7 +97,7 @@
       "name": "os_family",
       "type": "string",
       "description": "OS GCP image family",
-      "default": "daos-client-centos-7",
+      "default": "daos-client-hpc-centos-7",
       "required": false
     },
     {

--- a/terraform/modules/daos_client/variables.tf
+++ b/terraform/modules/daos_client/variables.tf
@@ -34,7 +34,7 @@ variable "labels" {
 
 variable "os_family" {
   description = "OS GCP image family"
-  default     = "daos-client-centos-7"
+  default     = "daos-client-hpc-centos-7"
   type        = string
 }
 


### PR DESCRIPTION
* Fixes DAOS-client defult to "daos-client-hpc-centos-7".
* Updated tflint to 0.16.1, which requires everyone to upgrade
  pre-commit. This is the latest tflint version that will run on current
  versions of pre-commit. Newer pre-commit versions will fail with
  0.12.x.

Signed-off-by: Carlos Boneti <carlosboneti@google.com>