### PR TITLE
DAOSGCP-115 Add depends_on for daos_ca secret

### DIFF
--- a/terraform/modules/daos_server/main.tf
+++ b/terraform/modules/daos_server/main.tf
@@ -177,6 +177,9 @@ resource "google_compute_instance_template" "daos_sig_template" {
 resource "google_compute_instance_group_manager" "daos_sig" {
   description = "Stateful Instance group for DAOS servers"
   name        = var.mig_name
+  depends_on  = [
+    google_secret_manager_secret.daos_ca
+  ]
 
   version {
     instance_template = google_compute_instance_template.daos_sig_template.self_link


### PR DESCRIPTION
Added a depends_on metadata attribute on the daos_server
sig to ensure that the daos_ca secret gets created
before the sig.

Signed-off-by: Mark A. Olson <mark.a.olson@intel.com>