### PR TITLE
Revert "Swap chmod/chown to fix wildcard expansion error"

### DIFF
--- a/images/daos-server-image.pkr.hcl
+++ b/images/daos-server-image.pkr.hcl
@@ -77,8 +77,8 @@ build {
     inline = [
       "sudo mkdir -p /var/daos/",
       "sudo mv /tmp/cert_gen /var/daos/",
-      "sudo chmod +x /var/daos/cert_gen/*.sh",
-      "sudo chown -R root:root /var/daos/cert_gen"
+      "sudo chown -R root:root /var/daos/cert_gen",
+      "sudo chmod +x /var/daos/cert_gen/*.sh"
     ]
   }
 }


### PR DESCRIPTION
This  was supposed to be submitted and merged to the develop branch.

The original PR will need to be re-submitted to the develop branch.  

Reverts daos-stack/google-cloud-daos#57