### PR TITLE
DAOSGCP-126 - Updates for DAOS v2.0.3

### DIFF
--- a/images/daos_version.sh
+++ b/images/daos_version.sh
@@ -15,7 +15,7 @@
 
 
 # Default DAOS version to be installed in images
-export DEFAULT_DAOS_VERSION="2.0"
+export DEFAULT_DAOS_VERSION="2.0.3"
 
 # Default DAOS packages repo
 export DEFAULT_DAOS_REPO_BASE_URL="https://packages.daos.io"

--- a/images/scripts/install_daos.sh
+++ b/images/scripts/install_daos.sh
@@ -181,11 +181,14 @@ add_repo() {
     centos_7)
       DAOS_OS_VERSION="CentOS7"
       ;;
+    almalinux_8)
+      DAOS_OS_VERSION="EL8"
+      ;;
     centos_8)
-      DAOS_OS_VERSION="CentOS8"
+      DAOS_OS_VERSION="EL8"
       ;;
     rocky_8)
-      DAOS_OS_VERSION="CentOS8"
+      DAOS_OS_VERSION="EL8"
       ;;
     *)
       log_error "ERROR: Unsupported OS: ${OS_VERSION_ID}. Exiting."
@@ -238,17 +241,6 @@ install_daos() {
   fi
 }
 
-downgrade_libfabric() {
-  if [[ ${DAOS_VERSION%%.*} == "2" ]]; then
-    log "Downgrading libfabric to v1.12 - see https://daosio.atlassian.net/browse/DAOS-9883"
-    wget https://packages.daos.io/v1.2/CentOS7/packages/x86_64/libfabric-1.12.0-1.el7.x86_64.rpm
-    rpm -i --force ./libfabric-1.12.0-1.el7.x86_64.rpm
-    rpm --erase --nodeps  libfabric-1.14.0
-    echo "exclude=libfabric" >> /etc/yum.repos.d/daos_packages.repo
-    rm -f ./libfabric-1.12.0-1.el7.x86_64.rpm
-  fi
-}
-
 install_additional_pkgs() {
   yum install -y clustershell curl git jq patch pdsh rsync wget
 }
@@ -262,7 +254,6 @@ main() {
   install_epel
   install_additional_pkgs
   install_daos
-  downgrade_libfabric
   printf "\n%s\n\n" "DONE! DAOS v${DAOS_VERSION} installed"
 }
 


### PR DESCRIPTION
DAOS v2.0.3 includes a libfabric upgrade which eliminates the need to downgrade libfabric for DAOS v2.0.x in the future.

This change removes the function in the images/scripts/install_daos.sh script which downgraded libfabric.

It also sets the default DAOS version to v2.0.3. 

Signed-off-by: Mark A. Olson <mark.a.olson@intel.com>