### PR TITLE
Swap chmod/chown to fix wildcard expansion error

### DIFF
--- a/images/daos-server-image.pkr.hcl
+++ b/images/daos-server-image.pkr.hcl
@@ -80,8 +80,8 @@ build {
     inline = [
       "sudo mkdir -p /var/daos/",
       "sudo mv /tmp/cert_gen /var/daos/",
-      "sudo chown -R root:root /var/daos/cert_gen",
-      "sudo chmod +x /var/daos/cert_gen/*.sh"
+      "sudo chmod +x /var/daos/cert_gen/*.sh",
+      "sudo chown -R root:root /var/daos/cert_gen"
     ]
   }
 }


### PR DESCRIPTION
 If

"sudo chmod +x /var/daos/cert_gen/*.sh"

is executed after

"sudo chown -R root:root /var/daos/cert_gen"

then there is no guarantee that the /var/daos/cert_gen/*.sh part is properly expanded. This is because expansion is performed by the shell invoking sudo and not by the command which is run under sudo. If the invoking shell does not have x permission on /var/daos/cert_gen then chmod will be passed the literal string "/var/daos/cert_gen/*.sh" which it will assume to be a valid path, which it is not.



Signed-off-by: Daniel Ahlin <50445206+danielahlin@users.noreply.github.com>