### PR TITLE
DAOSGCP-161 Fix setting the --region parameter

### DIFF
--- a/images/build_images.sh
+++ b/images/build_images.sh
@@ -328,7 +328,7 @@ build_images() {
     # When worker pool is specified then region needs to match the one of the pool.
     # Need to parse the correct region to use it instead of the default one "global".
     # Format: projects/{project}/locations/{region}/workerPools/{workerPool}
-    BUILD_WORKER_POOL_ARRAY=("${BUILD_WORKER_POOL//// }")
+    BUILD_WORKER_POOL_ARRAY=(${BUILD_WORKER_POOL//// })
     BUILD_REGION="${BUILD_WORKER_POOL_ARRAY[3]}"
     BUILD_OPTIONAL_ARGS+=" --worker-pool=${BUILD_WORKER_POOL}"
 


### PR DESCRIPTION
This fixes the following error while building an image:

```
$ ./build_daos_io500_images.sh -t all -i false -f -w projects/my-project/locations/us-central1/workerPools/build-pool-1
[INFO ] Building DAOS disk images for IO500

[INFO ] Temp directory for image building: /tmp/tmp.QZtFLQeShK
[INFO ] Building DAOS server image: daos-server-io500-centos-7
[INFO ] Building DAOS Image(s)
[INFO ] Packer will be using service account serviceAccount:805869098137@cloudbuild.gserviceaccount.com
[INFO ] Using build worker pool projects/my-project/locations/us-central1/workerPools/build-pool-1, region
[INFO ] Building server image
Creating temporary tarball archive of 12 file(s) totalling 38.5 KiB before compression.
Uploading tarball of [.] to [gs://my-project_cloudbuild/source/1677693367.658952-458724d827ce43e4a5c8ffbef94d79ef.tgz]
ERROR: (gcloud.builds.submit) Invalid value for [--region]: --region flag required when workerpool resource includes region substitution
```

This is because the region is parsed out as empty, which seems to be a regression introduced in the [previous commit](https://github.com/daos-stack/google-cloud-daos/commit/326d09e3e9503d7858f174b0fb4c1f7833116415#diff-df8b7cd939fc26a860e750c427d0e6e990f918a58194d8e630c9d8bbf8c4b571R331). 