### PR TITLE
DAOSGCP-151 Remove MIGs in Terraform modules

### DIFF
--- a/terraform/examples/daos_cluster/README.md
+++ b/terraform/examples/daos_cluster/README.md
@@ -26,7 +26,7 @@ As an alternative to viewing the instructions as a standalone document, you can 
 ## Terraform Configuration Documentation
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-Copyright 2022 Intel Corporation
+Copyright 2023 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -71,7 +71,6 @@ No resources.
 | <a name="input_client_instance_base_name"></a> [client\_instance\_base\_name](#input\_client\_instance\_base\_name) | MIG instance base names to use | `string` | `"daos-client"` | no |
 | <a name="input_client_labels"></a> [client\_labels](#input\_client\_labels) | Set of key/value label pairs to assign to daos-client instances | `any` | `{}` | no |
 | <a name="input_client_machine_type"></a> [client\_machine\_type](#input\_client\_machine\_type) | GCP machine type. ie. c2-standard-16 | `string` | `"c2-standard-16"` | no |
-| <a name="input_client_mig_name"></a> [client\_mig\_name](#input\_client\_mig\_name) | MIG name | `string` | `"daos-client"` | no |
 | <a name="input_client_number_of_instances"></a> [client\_number\_of\_instances](#input\_client\_number\_of\_instances) | Number of daos clients to bring up | `number` | `16` | no |
 | <a name="input_client_os_disk_size_gb"></a> [client\_os\_disk\_size\_gb](#input\_client\_os\_disk\_size\_gb) | OS disk size in GB | `number` | `20` | no |
 | <a name="input_client_os_disk_type"></a> [client\_os\_disk\_type](#input\_client\_os\_disk\_type) | OS disk type ie. pd-ssd, pd-standard | `string` | `"pd-ssd"` | no |
@@ -79,19 +78,16 @@ No resources.
 | <a name="input_client_os_project"></a> [client\_os\_project](#input\_client\_os\_project) | OS GCP image project name. Defaults to project\_id if null. | `string` | `null` | no |
 | <a name="input_client_preemptible"></a> [client\_preemptible](#input\_client\_preemptible) | If preemptible instances | `string` | `false` | no |
 | <a name="input_client_service_account"></a> [client\_service\_account](#input\_client\_service\_account) | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string,<br>    scopes = set(string)<br>  })</pre> | <pre>{<br>  "email": null,<br>  "scopes": [<br>    "https://www.googleapis.com/auth/devstorage.read_only",<br>    "https://www.googleapis.com/auth/logging.write",<br>    "https://www.googleapis.com/auth/monitoring.write",<br>    "https://www.googleapis.com/auth/servicecontrol",<br>    "https://www.googleapis.com/auth/service.management.readonly",<br>    "https://www.googleapis.com/auth/trace.append",<br>    "https://www.googleapis.com/auth/cloud-platform"<br>  ]<br>}</pre> | no |
-| <a name="input_client_template_name"></a> [client\_template\_name](#input\_client\_template\_name) | MIG template name | `string` | `"daos-client"` | no |
-| <a name="input_network_name"></a> [network\_name](#input\_network\_name) | Name of the GCP network to use | `string` | `"default"` | no |
-| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project to use | `string` | n/a | yes |
-| <a name="input_region"></a> [region](#input\_region) | The GCP region to create and test resources in | `string` | n/a | yes |
+| <a name="input_network_name"></a> [network\_name](#input\_network\_name) | Name of the GCP network | `string` | `"default"` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | The GCP region | `string` | n/a | yes |
 | <a name="input_server_daos_crt_timeout"></a> [server\_daos\_crt\_timeout](#input\_server\_daos\_crt\_timeout) | crt\_timeout | `number` | `300` | no |
 | <a name="input_server_daos_disk_count"></a> [server\_daos\_disk\_count](#input\_server\_daos\_disk\_count) | Number of local ssd's to use | `number` | `16` | no |
-| <a name="input_server_daos_disk_type"></a> [server\_daos\_disk\_type](#input\_server\_daos\_disk\_type) | Daos disk type to use. For now only suported one is local-ssd | `string` | `"local-ssd"` | no |
 | <a name="input_server_daos_scm_size"></a> [server\_daos\_scm\_size](#input\_server\_daos\_scm\_size) | scm\_size | `number` | `200` | no |
 | <a name="input_server_gvnic"></a> [server\_gvnic](#input\_server\_gvnic) | Use Google Virtual NIC (gVNIC) network interface | `bool` | `false` | no |
 | <a name="input_server_instance_base_name"></a> [server\_instance\_base\_name](#input\_server\_instance\_base\_name) | MIG instance base names to use | `string` | `"daos-server"` | no |
 | <a name="input_server_labels"></a> [server\_labels](#input\_server\_labels) | Set of key/value label pairs to assign to daos-server instances | `any` | `{}` | no |
 | <a name="input_server_machine_type"></a> [server\_machine\_type](#input\_server\_machine\_type) | GCP machine type. ie. e2-medium | `string` | `"n2-custom-36-215040"` | no |
-| <a name="input_server_mig_name"></a> [server\_mig\_name](#input\_server\_mig\_name) | MIG name | `string` | `"daos-server"` | no |
 | <a name="input_server_number_of_instances"></a> [server\_number\_of\_instances](#input\_server\_number\_of\_instances) | Number of daos servers to bring up | `number` | `4` | no |
 | <a name="input_server_os_disk_size_gb"></a> [server\_os\_disk\_size\_gb](#input\_server\_os\_disk\_size\_gb) | OS disk size in GB | `number` | `20` | no |
 | <a name="input_server_os_disk_type"></a> [server\_os\_disk\_type](#input\_server\_os\_disk\_type) | OS disk type ie. pd-ssd, pd-standard | `string` | `"pd-ssd"` | no |
@@ -100,10 +96,9 @@ No resources.
 | <a name="input_server_pools"></a> [server\_pools](#input\_server\_pools) | List of pools and containers to be created | <pre>list(object({<br>    name       = string<br>    size       = string<br>    tier_ratio = number<br>    user       = string<br>    group      = string<br>    acls       = list(string)<br>    properties = map(any)<br>    containers = list(object({<br>      name            = string<br>      type            = string<br>      user            = string<br>      group           = string<br>      acls            = list(string)<br>      properties      = map(any)<br>      user_attributes = map(any)<br>    }))<br>  }))</pre> | `[]` | no |
 | <a name="input_server_preemptible"></a> [server\_preemptible](#input\_server\_preemptible) | If preemptible instances | `string` | `false` | no |
 | <a name="input_server_service_account"></a> [server\_service\_account](#input\_server\_service\_account) | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string,<br>    scopes = set(string)<br>  })</pre> | <pre>{<br>  "email": null,<br>  "scopes": [<br>    "https://www.googleapis.com/auth/devstorage.read_only",<br>    "https://www.googleapis.com/auth/logging.write",<br>    "https://www.googleapis.com/auth/monitoring.write",<br>    "https://www.googleapis.com/auth/servicecontrol",<br>    "https://www.googleapis.com/auth/service.management.readonly",<br>    "https://www.googleapis.com/auth/trace.append",<br>    "https://www.googleapis.com/auth/cloud-platform"<br>  ]<br>}</pre> | no |
-| <a name="input_server_template_name"></a> [server\_template\_name](#input\_server\_template\_name) | MIG template name | `string` | `"daos-server"` | no |
-| <a name="input_subnetwork_name"></a> [subnetwork\_name](#input\_subnetwork\_name) | Name of the GCP sub-network to use | `string` | `"default"` | no |
+| <a name="input_subnetwork_name"></a> [subnetwork\_name](#input\_subnetwork\_name) | Name of the GCP sub-network | `string` | `"default"` | no |
 | <a name="input_subnetwork_project"></a> [subnetwork\_project](#input\_subnetwork\_project) | The GCP project where the subnetwork is defined | `string` | `null` | no |
-| <a name="input_zone"></a> [zone](#input\_zone) | The GCP zone to create and test resources in | `string` | n/a | yes |
+| <a name="input_zone"></a> [zone](#input\_zone) | The GCP zone | `string` | n/a | yes |
 
 ## Outputs
 

--- a/terraform/examples/daos_cluster/main.tf
+++ b/terraform/examples/daos_cluster/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Intel Corporation
+ * Copyright 2023 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,8 +29,6 @@ module "daos_server" {
   number_of_instances = var.server_number_of_instances
   labels              = var.server_labels
   preemptible         = var.server_preemptible
-  mig_name            = var.server_mig_name
-  template_name       = var.server_template_name
   instance_base_name  = var.server_instance_base_name
   machine_type        = var.server_machine_type
   os_family           = var.server_os_family
@@ -38,7 +36,6 @@ module "daos_server" {
   os_disk_type        = var.server_os_disk_type
   os_disk_size_gb     = var.server_os_disk_size_gb
   daos_disk_count     = var.server_daos_disk_count
-  daos_disk_type      = var.server_daos_disk_type
   daos_crt_timeout    = var.server_daos_crt_timeout
   daos_scm_size       = var.server_daos_scm_size
   service_account     = var.server_service_account
@@ -50,7 +47,6 @@ module "daos_server" {
 module "daos_client" {
   source                = "../../modules/daos_client"
   project_id            = var.project_id
-  region                = var.region
   zone                  = var.zone
   network_name          = var.network_name
   subnetwork_project    = var.subnetwork_project
@@ -58,8 +54,6 @@ module "daos_client" {
   number_of_instances   = var.client_number_of_instances
   labels                = var.client_labels
   preemptible           = var.client_preemptible
-  mig_name              = var.client_mig_name
-  template_name         = var.client_template_name
   instance_base_name    = var.client_instance_base_name
   machine_type          = var.client_machine_type
   os_family             = var.client_os_family

--- a/terraform/examples/daos_cluster/variables.tf
+++ b/terraform/examples/daos_cluster/variables.tf
@@ -15,28 +15,28 @@
  */
 
 variable "project_id" {
-  description = "The GCP project to use "
+  description = "The GCP project"
   type        = string
 }
 
 variable "region" {
-  description = "The GCP region to create and test resources in"
+  description = "The GCP region"
   type        = string
 }
 
 variable "zone" {
-  description = "The GCP zone to create and test resources in"
+  description = "The GCP zone"
   type        = string
 }
 
 variable "network_name" {
-  description = "Name of the GCP network to use"
+  description = "Name of the GCP network"
   default     = "default"
   type        = string
 }
 
 variable "subnetwork_name" {
-  description = "Name of the GCP sub-network to use"
+  description = "Name of the GCP sub-network"
   default     = "default"
   type        = string
 }
@@ -83,18 +83,6 @@ variable "server_os_disk_type" {
   type        = string
 }
 
-variable "server_template_name" {
-  description = "MIG template name"
-  default     = "daos-server"
-  type        = string
-}
-
-variable "server_mig_name" {
-  description = "MIG name "
-  default     = "daos-server"
-  type        = string
-}
-
 variable "server_machine_type" {
   description = "GCP machine type. ie. e2-medium"
   default     = "n2-custom-36-215040"
@@ -111,14 +99,6 @@ variable "server_number_of_instances" {
   description = "Number of daos servers to bring up"
   default     = 4
   type        = number
-}
-
-variable "server_daos_disk_type" {
-  #TODO: At some point we will support more than local-ssd with NVME
-  # interface.  This variable will be useful then. For now its just this.
-  description = "Daos disk type to use. For now only suported one is local-ssd"
-  default     = "local-ssd"
-  type        = string
 }
 
 variable "server_daos_disk_count" {
@@ -220,18 +200,6 @@ variable "client_os_disk_size_gb" {
 variable "client_os_disk_type" {
   description = "OS disk type ie. pd-ssd, pd-standard"
   default     = "pd-ssd"
-  type        = string
-}
-
-variable "client_template_name" {
-  description = "MIG template name"
-  default     = "daos-client"
-  type        = string
-}
-
-variable "client_mig_name" {
-  description = "MIG name "
-  default     = "daos-client"
   type        = string
 }
 

--- a/terraform/examples/io500/start.sh
+++ b/terraform/examples/io500/start.sh
@@ -290,14 +290,9 @@ run_terraform() {
 
 configure_first_client_ip() {
 
-  log.info "Wait for DAOS client instances"
   # shellcheck disable=SC2154
-  gcloud compute instance-groups managed wait-until "${TF_VAR_client_template_name}" \
-    --stable \
-    --project="${TF_VAR_project_id}" \
-    --zone="${TF_VAR_zone}"
-
   if [[ "${USE_INTERNAL_IP}" -eq 1 ]]; then
+    # shellcheck disable=SC2154
     FIRST_CLIENT_IP=$(gcloud compute instances describe "${DAOS_FIRST_CLIENT}" \
       --project="${TF_VAR_project_id}" \
       --zone="${TF_VAR_zone}" \

--- a/terraform/modules/daos_client/README.md
+++ b/terraform/modules/daos_client/README.md
@@ -9,7 +9,7 @@ The resources/services/activations/deletions that this module will create/trigge
 - Create a stateful instance group for DAOS clients
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-Copyright 2021 Google LLC
+Copyright 2023 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -46,9 +46,8 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [google-beta_google_compute_instance_template.daos_sig_template](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_compute_instance_template) | resource |
-| [google_compute_instance_group_manager.daos_sig](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_group_manager) | resource |
-| [google_compute_per_instance_config.named_instances](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_per_instance_config) | resource |
+| [google-beta_google_compute_instance.named_instances](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_compute_instance) | resource |
+| [google_compute_disk.boot_disk](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk) | resource |
 | [google_compute_image.os_image](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
 
 ## Inputs
@@ -62,7 +61,6 @@ No modules.
 | <a name="input_instance_base_name"></a> [instance\_base\_name](#input\_instance\_base\_name) | MIG instance base names to use | `string` | `"daos-client"` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Set of key/value label pairs to assign to daos-client instances | `any` | `{}` | no |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | GCP machine type. ie. c2-standard-16 | `string` | `"c2-standard-16"` | no |
-| <a name="input_mig_name"></a> [mig\_name](#input\_mig\_name) | MIG name | `string` | `"daos-client"` | no |
 | <a name="input_network_name"></a> [network\_name](#input\_network\_name) | Name of the GCP network to use | `string` | `"default"` | no |
 | <a name="input_number_of_instances"></a> [number\_of\_instances](#input\_number\_of\_instances) | Number of daos clients to bring up | `number` | `4` | no |
 | <a name="input_os_disk_size_gb"></a> [os\_disk\_size\_gb](#input\_os\_disk\_size\_gb) | OS disk size in GB | `number` | `20` | no |
@@ -71,11 +69,9 @@ No modules.
 | <a name="input_os_project"></a> [os\_project](#input\_os\_project) | OS GCP image project name. Defaults to project\_id if null. | `string` | `null` | no |
 | <a name="input_preemptible"></a> [preemptible](#input\_preemptible) | If preemptible instances | `string` | `false` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project to use | `string` | n/a | yes |
-| <a name="input_region"></a> [region](#input\_region) | The GCP region to create and test resources in | `string` | n/a | yes |
 | <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string,<br>    scopes = set(string)<br>  })</pre> | <pre>{<br>  "email": null,<br>  "scopes": [<br>    "https://www.googleapis.com/auth/devstorage.read_only",<br>    "https://www.googleapis.com/auth/logging.write",<br>    "https://www.googleapis.com/auth/monitoring.write",<br>    "https://www.googleapis.com/auth/servicecontrol",<br>    "https://www.googleapis.com/auth/service.management.readonly",<br>    "https://www.googleapis.com/auth/trace.append",<br>    "https://www.googleapis.com/auth/cloud-platform"<br>  ]<br>}</pre> | no |
 | <a name="input_subnetwork_name"></a> [subnetwork\_name](#input\_subnetwork\_name) | Name of the GCP sub-network to use | `string` | `"default"` | no |
 | <a name="input_subnetwork_project"></a> [subnetwork\_project](#input\_subnetwork\_project) | The GCP project where the subnetwork is defined | `string` | `null` | no |
-| <a name="input_template_name"></a> [template\_name](#input\_template\_name) | MIG template name | `string` | `"daos-client"` | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | The GCP zone to create and test resources in | `string` | n/a | yes |
 
 ## Outputs

--- a/terraform/modules/daos_client/main.tf
+++ b/terraform/modules/daos_client/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,23 +35,39 @@ data "google_compute_image" "os_image" {
   project = local.os_project
 }
 
-resource "google_compute_instance_template" "daos_sig_template" {
+resource "google_compute_disk" "boot_disk" {
+  project = var.project_id
+  count   = var.number_of_instances
+  name    = format("%s-%04d-boot-disk", var.instance_base_name, count.index + 1)
+  image   = data.google_compute_image.os_image.self_link
+  type    = var.os_disk_type
+  size    = var.os_disk_size_gb
+  zone    = var.zone
+}
+
+resource "google_compute_instance" "named_instances" {
   provider       = google-beta
-  name           = var.template_name
-  machine_type   = var.machine_type
+  zone           = var.zone
+  project        = var.project_id
+  labels         = var.labels
+  count          = var.number_of_instances
+  name           = format("%s-%04d", var.instance_base_name, count.index + 1)
   can_ip_forward = false
   tags           = ["daos-client"]
-  project        = var.project_id
-  region         = var.region
-  labels         = var.labels
-  count          = var.number_of_instances > 0 ? 1 : 0
+  machine_type   = var.machine_type
 
-  disk {
-    source_image = data.google_compute_image.os_image.self_link
-    auto_delete  = true
-    boot         = true
-    disk_type    = var.os_disk_type
-    disk_size_gb = var.os_disk_size_gb
+  metadata = {
+    inst_type                 = "daos-client"
+    enable-oslogin            = "true"
+    daos_control_yaml_content = var.daos_control_yml
+    daos_agent_yaml_content   = var.daos_agent_yml
+    startup-script            = local.startup_script
+  }
+
+
+  boot_disk {
+    source      = google_compute_disk.boot_disk[count.index].self_link
+    auto_delete = true
   }
 
   network_interface {
@@ -76,40 +92,5 @@ resource "google_compute_instance_template" "daos_sig_template" {
   scheduling {
     preemptible       = var.preemptible
     automatic_restart = false
-  }
-}
-
-resource "google_compute_instance_group_manager" "daos_sig" {
-  description = "Stateful Instance group for DAOS clients"
-  name        = var.mig_name
-  count       = var.number_of_instances > 0 ? 1 : 0
-  version {
-    instance_template = google_compute_instance_template.daos_sig_template[0].self_link
-  }
-
-  base_instance_name = var.instance_base_name
-  zone               = var.zone
-  project            = var.project_id
-}
-
-
-resource "google_compute_per_instance_config" "named_instances" {
-  zone                   = var.zone
-  project                = var.project_id
-  instance_group_manager = google_compute_instance_group_manager.daos_sig[0].name
-  count                  = var.number_of_instances
-  name                   = format("%s-%04d", var.instance_base_name, sum([count.index, 1]))
-  preserved_state {
-    metadata = {
-      inst_type                 = "daos-client"
-      enable-oslogin            = "true"
-      daos_control_yaml_content = var.daos_control_yml
-      daos_agent_yaml_content   = var.daos_agent_yml
-      startup-script            = local.startup_script
-      # Adding a reference to the instance template used causes the stateful instance to update
-      # if the instance template changes. Otherwise there is no explicit dependency and template
-      # changes may not occur on the stateful instance
-      instance_template = google_compute_instance_template.daos_sig_template[0].self_link
-    }
   }
 }

--- a/terraform/modules/daos_client/variables.tf
+++ b/terraform/modules/daos_client/variables.tf
@@ -17,10 +17,7 @@ variable "project_id" {
   description = "The GCP project to use "
   type        = string
 }
-variable "region" {
-  description = "The GCP region to create and test resources in"
-  type        = string
-}
+
 variable "zone" {
   description = "The GCP zone to create and test resources in"
   type        = string
@@ -53,18 +50,6 @@ variable "os_disk_size_gb" {
 variable "os_disk_type" {
   description = "OS disk type ie. pd-ssd, pd-standard"
   default     = "pd-ssd"
-  type        = string
-}
-
-variable "template_name" {
-  description = "MIG template name"
-  default     = "daos-client"
-  type        = string
-}
-
-variable "mig_name" {
-  description = "MIG name "
-  default     = "daos-client"
   type        = string
 }
 

--- a/terraform/modules/daos_server/README.md
+++ b/terraform/modules/daos_server/README.md
@@ -46,9 +46,8 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [google-beta_google_compute_instance_template.daos_sig_template](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_compute_instance_template) | resource |
-| [google_compute_instance_group_manager.daos_sig](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_group_manager) | resource |
-| [google_compute_per_instance_config.named_instances](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_per_instance_config) | resource |
+| [google-beta_google_compute_instance.named_instances](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_compute_instance) | resource |
+| [google_compute_disk.daos_server_boot_disk](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk) | resource |
 | [google_secret_manager_secret.daos_ca](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
 | [google_secret_manager_secret_iam_policy.daos_ca_secret_policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_policy) | resource |
 | [google_compute_default_service_account.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_default_service_account) | data source |
@@ -62,13 +61,11 @@ No modules.
 | <a name="input_allow_insecure"></a> [allow\_insecure](#input\_allow\_insecure) | Sets the allow\_insecure setting in the transport\_config section of the daos\_*.yml files | `bool` | `false` | no |
 | <a name="input_daos_crt_timeout"></a> [daos\_crt\_timeout](#input\_daos\_crt\_timeout) | crt\_timeout | `number` | `300` | no |
 | <a name="input_daos_disk_count"></a> [daos\_disk\_count](#input\_daos\_disk\_count) | Number of local ssd's to use | `number` | `16` | no |
-| <a name="input_daos_disk_type"></a> [daos\_disk\_type](#input\_daos\_disk\_type) | Daos disk type to use. For now only suported one is local-ssd | `string` | `"local-ssd"` | no |
 | <a name="input_daos_scm_size"></a> [daos\_scm\_size](#input\_daos\_scm\_size) | scm\_size | `number` | `200` | no |
 | <a name="input_gvnic"></a> [gvnic](#input\_gvnic) | Use Google Virtual NIC (gVNIC) network interface | `bool` | `false` | no |
 | <a name="input_instance_base_name"></a> [instance\_base\_name](#input\_instance\_base\_name) | MIG instance base names to use | `string` | `"daos-server"` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Set of key/value label pairs to assign to daos-server instances | `any` | `{}` | no |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | GCP machine type. ie. e2-medium | `string` | `"n2-custom-36-215040"` | no |
-| <a name="input_mig_name"></a> [mig\_name](#input\_mig\_name) | MIG name | `string` | `"daos-server"` | no |
 | <a name="input_network_name"></a> [network\_name](#input\_network\_name) | Name of the GCP network to use | `string` | `"default"` | no |
 | <a name="input_number_of_instances"></a> [number\_of\_instances](#input\_number\_of\_instances) | Number of daos servers to bring up | `number` | `4` | no |
 | <a name="input_os_disk_size_gb"></a> [os\_disk\_size\_gb](#input\_os\_disk\_size\_gb) | OS disk size in GB | `number` | `20` | no |
@@ -82,7 +79,6 @@ No modules.
 | <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string,<br>    scopes = set(string)<br>  })</pre> | <pre>{<br>  "email": null,<br>  "scopes": [<br>    "https://www.googleapis.com/auth/devstorage.read_only",<br>    "https://www.googleapis.com/auth/logging.write",<br>    "https://www.googleapis.com/auth/monitoring.write",<br>    "https://www.googleapis.com/auth/servicecontrol",<br>    "https://www.googleapis.com/auth/service.management.readonly",<br>    "https://www.googleapis.com/auth/trace.append",<br>    "https://www.googleapis.com/auth/cloud-platform"<br>  ]<br>}</pre> | no |
 | <a name="input_subnetwork_name"></a> [subnetwork\_name](#input\_subnetwork\_name) | Name of the GCP sub-network to use | `string` | `"default"` | no |
 | <a name="input_subnetwork_project"></a> [subnetwork\_project](#input\_subnetwork\_project) | The GCP project where the subnetwork is defined | `string` | `null` | no |
-| <a name="input_template_name"></a> [template\_name](#input\_template\_name) | MIG template name | `string` | `"daos-server"` | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | The GCP zone to create and test resources in | `string` | n/a | yes |
 
 ## Outputs

--- a/terraform/modules/daos_server/main.tf
+++ b/terraform/modules/daos_server/main.tf
@@ -120,32 +120,49 @@ data "google_compute_image" "os_image" {
   project = local.os_project
 }
 
-resource "google_compute_instance_template" "daos_sig_template" {
-  provider       = google-beta
-  name           = var.template_name
-  machine_type   = var.machine_type
+resource "google_compute_disk" "daos_server_boot_disk" {
+  project = var.project_id
+  count   = var.number_of_instances
+  name    = format("%s-%04d-boot-disk", var.instance_base_name, count.index + 1)
+  image   = data.google_compute_image.os_image.self_link
+  type    = var.os_disk_type
+  size    = var.os_disk_size_gb
+  zone    = var.zone
+}
+
+resource "google_compute_instance" "named_instances" {
+  depends_on = [google_compute_disk.daos_server_boot_disk]
+  count      = var.number_of_instances
+  name       = format("%s-%04d", var.instance_base_name, count.index + 1)
+  provider   = google-beta
+  project    = var.project_id
+  zone       = var.zone
+  labels     = var.labels
+
   can_ip_forward = false
   tags           = ["daos-server"]
-  project        = var.project_id
-  region         = var.region
-  labels         = var.labels
+  machine_type   = var.machine_type
 
-  disk {
-    source_image = data.google_compute_image.os_image.self_link
-    auto_delete  = true
-    boot         = true
-    disk_type    = var.os_disk_type
-    disk_size_gb = var.os_disk_size_gb
+  metadata = {
+    inst_type                 = "daos-server"
+    enable-oslogin            = "true"
+    inst_nr                   = var.number_of_instances
+    inst_base_name            = var.instance_base_name
+    daos_server_yaml_content  = local.daos_server_yaml_content
+    daos_control_yaml_content = local.daos_control_yaml_content
+    daos_agent_yaml_content   = local.daos_agent_yaml_content
+    startup-script            = local.startup_script
   }
 
-  dynamic "disk" {
-    for_each = toset(range(var.daos_disk_count))
+  boot_disk {
+    source      = google_compute_disk.daos_server_boot_disk[count.index].self_link
+    auto_delete = true
+  }
+
+  dynamic "scratch_disk" {
+    for_each = range(var.daos_disk_count)
     content {
-      auto_delete  = true
-      interface    = "NVME"
-      disk_type    = var.daos_disk_type
-      disk_size_gb = 375
-      type         = "SCRATCH"
+      interface = "NVME"
     }
   }
 
@@ -174,65 +191,14 @@ resource "google_compute_instance_template" "daos_sig_template" {
   }
 }
 
-resource "google_compute_instance_group_manager" "daos_sig" {
-  description = "Stateful Instance group for DAOS servers"
-  name        = var.mig_name
-  depends_on = [
-    google_secret_manager_secret.daos_ca
-  ]
-
-  version {
-    instance_template = google_compute_instance_template.daos_sig_template.self_link
-  }
-
-  base_instance_name = var.instance_base_name
-  zone               = var.zone
-  project            = var.project_id
-}
-
-
-resource "google_compute_per_instance_config" "named_instances" {
-  zone                   = var.zone
-  project                = var.project_id
-  instance_group_manager = google_compute_instance_group_manager.daos_sig.name
-  count                  = var.number_of_instances
-  name                   = format("%s-%04d", var.instance_base_name, sum([count.index, 1]))
-  preserved_state {
-    metadata = {
-      inst_type                 = "daos-server"
-      enable-oslogin            = "true"
-      inst_nr                   = var.number_of_instances
-      inst_base_name            = var.instance_base_name
-      daos_server_yaml_content  = local.daos_server_yaml_content
-      daos_control_yaml_content = local.daos_control_yaml_content
-      daos_agent_yaml_content   = local.daos_agent_yaml_content
-      startup-script            = local.startup_script
-      # Adding a reference to the instance template used causes the stateful instance to update
-      # if the instance template changes. Otherwise there is no explicit dependency and template
-      # changes may not occur on the stateful instance
-      instance_template = google_compute_instance_template.daos_sig_template.self_link
-    }
-  }
-}
-
-resource "google_secret_manager_secret" "daos_ca" {
-  secret_id = format("%s_ca", var.instance_base_name)
-  project   = var.project_id
-
-  replication {
-    user_managed {
-      replicas {
-        location = var.region
-      }
-    }
-  }
-}
 
 data "google_compute_default_service_account" "default" {
   project = var.project_id
 }
 
+
 data "google_iam_policy" "daos_ca_secret_version_manager" {
+  count = !local.allow_insecure ? 1 : 0
   binding {
     role = "roles/secretmanager.secretVersionManager"
     members = [
@@ -253,8 +219,21 @@ data "google_iam_policy" "daos_ca_secret_version_manager" {
   }
 }
 
+resource "google_secret_manager_secret" "daos_ca" {
+  secret_id = format("%s_ca", var.instance_base_name)
+  project   = var.project_id
+
+  replication {
+    user_managed {
+      replicas {
+        location = var.region
+      }
+    }
+  }
+}
+
 resource "google_secret_manager_secret_iam_policy" "daos_ca_secret_policy" {
   project     = var.project_id
   secret_id   = google_secret_manager_secret.daos_ca.secret_id
-  policy_data = data.google_iam_policy.daos_ca_secret_version_manager.policy_data
+  policy_data = data.google_iam_policy.daos_ca_secret_version_manager[0].policy_data
 }

--- a/terraform/modules/daos_server/variables.tf
+++ b/terraform/modules/daos_server/variables.tf
@@ -17,10 +17,12 @@ variable "project_id" {
   description = "The GCP project to use "
   type        = string
 }
+
 variable "region" {
   description = "The GCP region to create and test resources in"
   type        = string
 }
+
 variable "zone" {
   description = "The GCP zone to create and test resources in"
   type        = string
@@ -53,18 +55,6 @@ variable "os_disk_size_gb" {
 variable "os_disk_type" {
   description = "OS disk type ie. pd-ssd, pd-standard"
   default     = "pd-ssd"
-  type        = string
-}
-
-variable "template_name" {
-  description = "MIG template name"
-  default     = "daos-server"
-  type        = string
-}
-
-variable "mig_name" {
-  description = "MIG name "
-  default     = "daos-server"
   type        = string
 }
 
@@ -102,14 +92,6 @@ variable "number_of_instances" {
   description = "Number of daos servers to bring up"
   default     = 4
   type        = number
-}
-
-variable "daos_disk_type" {
-  #TODO: At some point we will support more than local-ssd with NVME
-  # interface.  This variable will be useful then. For now its just this.
-  description = "Daos disk type to use. For now only suported one is local-ssd"
-  default     = "local-ssd"
-  type        = string
 }
 
 variable "daos_disk_count" {


### PR DESCRIPTION
Remove Managed Instance Group (MIG) provisioning from Terrform modules.

For large deployments provisioning instances with google_compute_instance vs google_compute_instance_group_manager reduces provisioning time.

This change was provided by Margaret Lawson.

Signed-off-by: Margaret Lawson <mlawsonca@google.com>
Signed-off-by: Mark Olson <115657904+mark-olson@users.noreply.github.com>