### PR TITLE
DAOSGCP-165 Support for DAOS > v2.2.0

### DIFF
--- a/images/build.sh
+++ b/images/build.sh
@@ -60,6 +60,19 @@ log.info() { log "${1}" "INFO"; }
 log.warn() { log "${1}" "WARN"; }
 log.error() { log "${1}" "ERROR"; }
 log.fatal() { log "${1}" "FATAL"; }
+
+log.debug.show_vars() {
+  if [[ "${LOG_LEVEL}" == "DEBUG" ]]; then
+    local script_vars
+    echo
+    log.debug "=== Environment variables ==="
+    readarray -t script_vars < <(compgen -A variable | grep "DAOS_\|GCP_" | sort)
+    for script_var in "${script_vars[@]}"; do
+      log.debug "${script_var}=${!script_var}"
+    done
+    echo
+  fi
+}
 # END: Logging variables and functions
 
 show_help() {
@@ -314,31 +327,10 @@ list_images() {
     --sort-by="creationTimestamp"
 }
 
-show_vars() {
-  log.debug "GCP_PROJECT                   ${GCP_PROJECT}"
-  log.debug "GCP_ZONE                      ${GCP_ZONE}"
-  log.debug "GCP_BUILD_WORKER_POOL         ${GCP_BUILD_WORKER_POOL}"
-  log.debug "GCP_USE_IAP                   ${GCP_USE_IAP}"
-  log.debug "GCP_ENABLE_OSLOGIN            ${GCP_ENABLE_OSLOGIN}"
-  log.debug "GCP_USE_CLOUDBUILD            ${GCP_USE_CLOUDBUILD}"
-  log.debug "GCP_CONFIGURE_PROJECT         ${GCP_CONFIGURE_PROJECT}"
-  log.debug "DAOS_VERSION                  ${DAOS_VERSION}"
-  log.debug "DAOS_REPO_BASE_URL            ${DAOS_REPO_BASE_URL}"
-  log.debug "DAOS_MACHINE_TYPE             ${DAOS_MACHINE_TYPE}"
-  log.debug "DAOS_SOURCE_IMAGE_FAMILY      ${DAOS_SOURCE_IMAGE_FAMILY}"
-  log.debug "DAOS_SOURCE_IMAGE_PROJECT_ID  ${DAOS_SOURCE_IMAGE_PROJECT_ID}"
-  log.debug "DAOS_SERVER_IMAGE_FAMILY      ${DAOS_SERVER_IMAGE_FAMILY}"
-  log.debug "DAOS_CLIENT_IMAGE_FAMILY      ${DAOS_CLIENT_IMAGE_FAMILY}"
-  log.debug "DAOS_BUILD_SERVER_IMAGE       ${DAOS_BUILD_SERVER_IMAGE}"
-  log.debug "DAOS_BUILD_CLIENT_IMAGE       ${DAOS_BUILD_CLIENT_IMAGE}"
-  log.debug "DAOS_PACKER_TEMPLATE          ${DAOS_PACKER_TEMPLATE}"
-  log.debug "DAOS_PACKER_VARS_FILE         ${DAOS_PACKER_VARS_FILE}"
-}
-
 main() {
   init
   opts "$@"
-  show_vars
+  log.debug.show_vars
   build_server_image
   build_client_image
   list_images

--- a/terraform/examples/io500/bin/_log.sh
+++ b/terraform/examples/io500/bin/_log.sh
@@ -71,4 +71,17 @@ log.section() {
     if [[ -t 1 ]]; then tput sgr0; fi
   fi
 }
+
+log.debug.show_vars() {
+  if [[ "${LOG_LEVEL}" == "DEBUG" ]]; then
+    local script_vars
+    echo
+    log.debug "=== Environment variables ==="
+    readarray -t script_vars < <(compgen -A variable | grep "DAOS_\|GCP_\|IO500_" | sort)
+    for script_var in "${script_vars[@]}"; do
+      log.debug "${script_var}=${!script_var}"
+    done
+    echo
+  fi
+}
 # END: Logging variables and functions

--- a/terraform/examples/io500/bin/stop.sh
+++ b/terraform/examples/io500/bin/stop.sh
@@ -26,9 +26,6 @@ ACTIVE_CONFIG_SYMLINK="${CONFIG_DIR}/active_config.sh"
 # shellcheck source=_log.sh
 source "${SCRIPT_DIR}/_log.sh"
 
-# shellcheck disable=SC2034
-LOG_LEVEL="DEBUG"
-
 # active_config.sh is a symlink to the last config file used by start.sh
 # shellcheck source=/dev/null
 # Source the active config file that was last used by ./start.sh
@@ -43,6 +40,8 @@ fi
 # Source the last configuration that was used by the start.sh script
 # shellcheck source=/dev/null
 source "$(readlink "${ACTIVE_CONFIG_SYMLINK}")"
+
+log.debug.show_vars
 
 log.section "Destroying DAOS Servers & Clients"
 cd "${TF_DIR}"

--- a/terraform/examples/io500/config/GCP-10C-4S16d-rf0.sh
+++ b/terraform/examples/io500/config/GCP-10C-4S16d-rf0.sh
@@ -47,6 +47,7 @@ DAOS_CLIENT_IMAGE_FAMILY="daos-client-io500-hpc-rocky-8"
 # Storage
 DAOS_POOL_SIZE="$(awk -v disk_count=${DAOS_SERVER_DISK_COUNT} -v server_count=${DAOS_SERVER_INSTANCE_COUNT} 'BEGIN {pool_size = 375 * disk_count * server_count / 1000; print pool_size"TB"}')"
 DAOS_CONT_REPLICATION_FACTOR="rf:0"
+DAOS_CHUNK_SIZE="1048576" # 1MB
 
 # IO500
 IO500_TEST_CONFIG_ID="GCP-10C-4S16d-rf0"

--- a/terraform/examples/io500/config/GCP-16C-4S16d-rf0.sh
+++ b/terraform/examples/io500/config/GCP-16C-4S16d-rf0.sh
@@ -47,6 +47,7 @@ DAOS_CLIENT_IMAGE_FAMILY="daos-client-io500-hpc-rocky-8"
 # Storage
 DAOS_POOL_SIZE="$(awk -v disk_count=${DAOS_SERVER_DISK_COUNT} -v server_count=${DAOS_SERVER_INSTANCE_COUNT} 'BEGIN {pool_size = 375 * disk_count * server_count / 1000; print pool_size"TB"}')"
 DAOS_CONT_REPLICATION_FACTOR="rf:0"
+DAOS_CHUNK_SIZE="1048576" # 1MB
 
 # IO500
 IO500_TEST_CONFIG_ID="GCP-16C-4S16d-rf0"

--- a/terraform/examples/io500/config/GCP-1C-1S8d-rf0.sh
+++ b/terraform/examples/io500/config/GCP-1C-1S8d-rf0.sh
@@ -47,6 +47,7 @@ DAOS_CLIENT_IMAGE_FAMILY="daos-client-io500-hpc-rocky-8"
 # Storage
 DAOS_POOL_SIZE="$(awk -v disk_count=${DAOS_SERVER_DISK_COUNT} -v server_count=${DAOS_SERVER_INSTANCE_COUNT} 'BEGIN {pool_size = 375 * disk_count * server_count / 1000; print pool_size"TB"}')"
 DAOS_CONT_REPLICATION_FACTOR="rf:0"
+DAOS_CHUNK_SIZE="1048576" # 1MB
 
 # IO500
 IO500_TEST_CONFIG_ID="GCP-1C-1S8d-rf0"

--- a/terraform/examples/io500/config/GCP-2C-1S8d-rf0.sh
+++ b/terraform/examples/io500/config/GCP-2C-1S8d-rf0.sh
@@ -47,6 +47,7 @@ DAOS_CLIENT_IMAGE_FAMILY="daos-client-io500-hpc-rocky-8"
 # Storage
 DAOS_POOL_SIZE="$(awk -v disk_count=${DAOS_SERVER_DISK_COUNT} -v server_count=${DAOS_SERVER_INSTANCE_COUNT} 'BEGIN {pool_size = 375 * disk_count * server_count / 1000; print pool_size"TB"}')"
 DAOS_CONT_REPLICATION_FACTOR="rf:0"
+DAOS_CHUNK_SIZE="1048576" # 1MB
 
 # IO500
 IO500_TEST_CONFIG_ID="GCP-2C-1S8d-rf0"

--- a/terraform/examples/io500/config/GCP-32C-10S16d-rf2.sh
+++ b/terraform/examples/io500/config/GCP-32C-10S16d-rf2.sh
@@ -46,6 +46,7 @@ DAOS_CLIENT_IMAGE_FAMILY="daos-client-io500-hpc-rocky-8"
 # Storage
 DAOS_POOL_SIZE="$(awk -v disk_count=${DAOS_SERVER_DISK_COUNT} -v server_count=${DAOS_SERVER_INSTANCE_COUNT} 'BEGIN {pool_size = 375 * disk_count * server_count / 1000; print pool_size"TB"}')"
 DAOS_CONT_REPLICATION_FACTOR="rf:2"
+DAOS_CHUNK_SIZE="1048576" # 1MB
 
 # IO500
 IO500_TEST_CONFIG_ID="GCP-32C-10S16d-rf2"

--- a/terraform/examples/io500/config/GCP-32C-8S16d-rf0.sh
+++ b/terraform/examples/io500/config/GCP-32C-8S16d-rf0.sh
@@ -47,6 +47,7 @@ DAOS_CLIENT_IMAGE_FAMILY="daos-client-io500-hpc-rocky-8"
 # Storage
 DAOS_POOL_SIZE="$(awk -v disk_count=${DAOS_SERVER_DISK_COUNT} -v server_count=${DAOS_SERVER_INSTANCE_COUNT} 'BEGIN {pool_size = 375 * disk_count * server_count / 1000; print pool_size"TB"}')"
 DAOS_CONT_REPLICATION_FACTOR="rf:0"
+DAOS_CHUNK_SIZE="1048576" # 1MB
 
 # IO500
 IO500_TEST_CONFIG_ID="GCP-32C-8S16d-rf0"

--- a/terraform/examples/io500/config/GCP-32C-9S16d-rf1.sh
+++ b/terraform/examples/io500/config/GCP-32C-9S16d-rf1.sh
@@ -46,6 +46,7 @@ DAOS_CLIENT_IMAGE_FAMILY="daos-client-io500-hpc-rocky-8"
 # Storage
 DAOS_POOL_SIZE="$(awk -v disk_count=${DAOS_SERVER_DISK_COUNT} -v server_count=${DAOS_SERVER_INSTANCE_COUNT} 'BEGIN {pool_size = 375 * disk_count * server_count / 1000; print pool_size"TB"}')"
 DAOS_CONT_REPLICATION_FACTOR="rf:1"
+DAOS_CHUNK_SIZE="1048576" # 1MB
 
 # IO500
 IO500_TEST_CONFIG_ID="GCP-32C-9S16d-rf1"

--- a/terraform/examples/io500/config/GCP-4C-1S8d-rf0.sh
+++ b/terraform/examples/io500/config/GCP-4C-1S8d-rf0.sh
@@ -47,6 +47,7 @@ DAOS_CLIENT_IMAGE_FAMILY="daos-client-io500-hpc-rocky-8"
 # Storage
 DAOS_POOL_SIZE="$(awk -v disk_count=${DAOS_SERVER_DISK_COUNT} -v server_count=${DAOS_SERVER_INSTANCE_COUNT} 'BEGIN {pool_size = 375 * disk_count * server_count / 1000; print pool_size"TB"}')"
 DAOS_CONT_REPLICATION_FACTOR="rf:0"
+DAOS_CHUNK_SIZE="1048576" # 1MB
 
 # IO500
 IO500_TEST_CONFIG_ID="GCP-4C-1S8d-rf0"

--- a/terraform/examples/io500/config/GCP-8C-2S16d-rf0.sh
+++ b/terraform/examples/io500/config/GCP-8C-2S16d-rf0.sh
@@ -47,6 +47,7 @@ DAOS_CLIENT_IMAGE_FAMILY="daos-client-io500-hpc-rocky-8"
 # Storage
 DAOS_POOL_SIZE="$(awk -v disk_count=${DAOS_SERVER_DISK_COUNT} -v server_count=${DAOS_SERVER_INSTANCE_COUNT} 'BEGIN {pool_size = 375 * disk_count * server_count / 1000; print pool_size"TB"}')"
 DAOS_CONT_REPLICATION_FACTOR="rf:0"
+DAOS_CHUNK_SIZE="1048576" # 1MB
 
 # IO500
 IO500_TEST_CONFIG_ID="GCP-8C-2S16d-rf0"

--- a/terraform/modules/daos_server/templates/certs_install.inc.sh.tftpl
+++ b/terraform/modules/daos_server/templates/certs_install.inc.sh.tftpl
@@ -80,8 +80,6 @@ if [[ "$${DAOS_CLIENT_INSTALLED}" == "true" ]]; then
   cp /var/daos/daosCA/certs/agent.* /etc/daos/certs/
   chown -R daos_agent:daos_agent /etc/daos/certs
   chmod 0755 /etc/daos/certs
-  chmod 0644 /etc/daos/certs/*.crt
-  chmod 0600 /etc/daos/certs/*.key
 fi
 
 # SERVER CERTS
@@ -103,18 +101,11 @@ if [[ "$${DAOS_SERVER_INSTALLED}" == "true" ]]; then
 
   chmod 0755 /etc/daos/certs
   chmod 0755 /etc/daos/certs/clients
-
-  chmod 0644 /etc/daos/certs/*.crt
-  chmod 0600 /etc/daos/certs/*.key
-  chmod 0644 /etc/daos/certs/clients/*
 fi
 
 # INSTALL ADMIN CERTS ON CLIENTS AND SERVERS
 cp /var/daos/daosCA/certs/admin.* /etc/daos/certs/
 chown root:root /etc/daos/certs/admin.*
-chmod 0644 /etc/daos/certs/admin.crt
-# dmg requires 0700 admin.key
-chmod 0700 /etc/daos/certs/admin.key
 
 # Remove the CA dir now that the certs have been copied to /etc/daos/certs
 if [[ -d "/var/daos/daosCA" ]]; then

--- a/terraform/modules/daos_server/templates/pool_cont_create.inc.sh.tftpl
+++ b/terraform/modules/daos_server/templates/pool_cont_create.inc.sh.tftpl
@@ -2,31 +2,60 @@
 echo "BEGIN: DAOS pool and container creation from definition in 'pool' variable"
 
 if [[ "$${HOSTNAME,,}" == "$${FIRST_DAOS_SERVER_HOSTNAME,,}" ]]; then
+  daos_version=$(dmg version | awk '{print $3}')
+
   %{for pool in pools}
-  dmg pool create \
-    --size=${pool.size} \
-    --tier-ratio="${pool.tier_ratio}" \
-    --user="${pool.user}" \
-    --group="${pool.group}" \
-    %{~ if length(pool.properties) != 0 ~}
-    --properties="%{~ for idx, pprop_key in keys(pool.properties) ~}
-        ${~ pprop_key}:${pool.properties[pprop_key]}%{~ if idx != length(pool.properties)-1 ~},%{~ endif ~}%{~ endfor ~}" \
-      %{~ endif ~}
-    "${pool.name}"
+
+  if awk 'BEGIN{if(ARGV[1]<ARGV[2])exit 0;exit 1;}' $daos_version "2.3"; then
+    # Use older DAOS v2.2.x dmg options
+    dmg pool create \
+      --size=${pool.size} \
+      --tier-ratio="${pool.tier_ratio}" \
+      --user="${pool.user}" \
+      --group="${pool.group}" \
+      %{~ if length(pool.properties) != 0 ~}
+      --properties="%{~ for idx, pprop_key in keys(pool.properties) ~}
+          ${~ pprop_key}:${pool.properties[pprop_key]}%{~ if idx != length(pool.properties)-1 ~},%{~ endif ~}%{~ endfor ~}" \
+        %{~ endif ~}
+      "${pool.name}"
+  else
+    dmg pool create \
+      --size=${pool.size} \
+      --tier-ratio="${pool.tier_ratio}" \
+      --user="${pool.user}" \
+      --group="${pool.group}" \
+      %{~ if length(pool.properties) != 0 ~}
+      --properties="%{~ for idx, pprop_key in keys(pool.properties) ~}
+          ${~ pprop_key}:${pool.properties[pprop_key]}%{~ if idx != length(pool.properties)-1 ~},%{~ endif ~}%{~ endfor ~}" \
+        %{~ endif ~}
+      "${pool.name}"
+  fi
 
     %{~ for acl in pool.acls ~}
   dmg pool update-acl --entry "${acl}" "${pool.name}"
     %{~ endfor ~}
 
     %{~ for container in pool.containers ~}
-  daos container create \
-    --type ${container.type} \
-      %{~ if length(container.properties) != 0 ~}
-    --properties="%{~ for idx, cprop_key in keys(container.properties) ~}
-        ${~ cprop_key}:${container.properties[cprop_key]}%{~ if idx != length(container.properties)-1 ~},%{~ endif ~}%{~ endfor ~}" \
-      %{~ endif ~}
-    "${pool.name}" \
-    --label "${container.name}"
+  if awk 'BEGIN{if(ARGV[1]<ARGV[2])exit 0;exit 1;}' $daos_version "2.3"; then
+    daos container create \
+      --type ${container.type} \
+        %{~ if length(container.properties) != 0 ~}
+      --properties="%{~ for idx, cprop_key in keys(container.properties) ~}
+          ${~ cprop_key}:${container.properties[cprop_key]}%{~ if idx != length(container.properties)-1 ~},%{~ endif ~}%{~ endfor ~}" \
+        %{~ endif ~}
+      "${pool.name}" \
+      --label "${container.name}"
+  else
+    daos container create \
+      --type ${container.type} \
+        %{~ if length(container.properties) != 0 ~}
+      --properties="%{~ for idx, cprop_key in keys(container.properties) ~}
+          ${~ cprop_key}:${container.properties[cprop_key]}%{~ if idx != length(container.properties)-1 ~},%{~ endif ~}%{~ endfor ~}" \
+        %{~ endif ~}
+      "${pool.name}" \
+      "${container.name}"
+  fi
+
 
       %{~ for acl in container.acls ~}
   daos cont update-acl "${pool.name}" "${container.name}" --entry "${acl}"


### PR DESCRIPTION
Changes tested with DAOS v2.2.0 and v2.3.107

- dmg command line changes for >v2.2.0
- daos command line changes for >v2.2.0
- removed environment file from build_io500_images.sh so that vars pass through from config/*
- added ability to set chunk size in io500 configurations
- fix cert permissions to work with v2.2.0 and v2.3.*
- added log.debug.show_vars function for debugging

Signed-off-by: Mark Olson <115657904+mark-olson@users.noreply.github.com>