### PR TITLE
DAOSGCP-140 Configure 1 thread per vCPU

### DIFF
--- a/terraform/examples/io500/client_files/run_io500-sc22.sh
+++ b/terraform/examples/io500/client_files/run_io500-sc22.sh
@@ -232,7 +232,9 @@ io500_prepare() {
   export DAOS_POOL="${DAOS_POOL_LABEL}"
   export DAOS_CONT="${DAOS_CONT_LABEL}"
   export MFU_POSIX_TS=1
-  export IO500_NP=$((DAOS_CLIENT_INSTANCE_COUNT * $(nproc --all)))
+  export IO500_NP=$(( DAOS_CLIENT_INSTANCE_COUNT * $(nproc --all) ))
+  export IO500_PPN=$(( $(nproc --all) ))
+  export MPI_RUN_OPTS="--bind-to socket"
 
   # shellcheck disable=SC2153
   envsubst <"${IO500_INI}" >temp.ini
@@ -251,9 +253,14 @@ io500_prepare() {
 }
 
 run_io500() {
+  log.debug "COMMAND: mpirun -np ${IO500_NP} -ppn ${IO500_PPN} --hostfile ${SCRIPT_DIR}/hosts_clients ${MPI_RUN_OPTS} ${IO500_DIR}/io500 temp.ini"
+  # shellcheck disable=SC2086
   mpirun -np ${IO500_NP} \
+    -ppn ${IO500_PPN} \
     --hostfile "${SCRIPT_DIR}/hosts_clients" \
-    --bind-to socket "${IO500_DIR}/io500" temp.ini
+    $MPI_RUN_OPTS \
+    "${IO500_DIR}/io500" \
+    temp.ini
   log.info "IO500 run complete!"
 }
 

--- a/terraform/modules/daos_client/main.tf
+++ b/terraform/modules/daos_client/main.tf
@@ -93,4 +93,8 @@ resource "google_compute_instance" "named_instances" {
     preemptible       = var.preemptible
     automatic_restart = false
   }
+
+  advanced_machine_features {
+    threads_per_core = 1
+  }
 }

--- a/terraform/modules/daos_server/main.tf
+++ b/terraform/modules/daos_server/main.tf
@@ -189,6 +189,10 @@ resource "google_compute_instance" "named_instances" {
     preemptible       = var.preemptible
     automatic_restart = false
   }
+
+  advanced_machine_features {
+    threads_per_core = 1
+  }
 }
 
 


### PR DESCRIPTION
Reducing the number of threads that run on each physical CPU core can help improve the performance of workloads that are highly-parallel.

Signed-off-by: Mark Olson <115657904+mark-olson@users.noreply.github.com>