### PR TITLE
DAOSGCP-190 Ensure realpath is not used on non-existent dirs

### DIFF
--- a/terraform/examples/io500/bin/get_io500_result_data.sh
+++ b/terraform/examples/io500/bin/get_io500_result_data.sh
@@ -31,9 +31,10 @@ set -eo pipefail
 trap 'echo "Hit an unexpected and unchecked error. Exiting."' ERR
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
-LOCAL_RESULTS_DIR=$(realpath "${SCRIPT_DIR}/../results")
-TMP_DIR=$(realpath "${SCRIPT_DIR}/../.tmp")
-ACTIVE_CONFIG="${SCRIPT_DIR}/../config/active_config.sh"
+TF_DIR="$(realpath "${SCRIPT_DIR}/../")"
+LOCAL_RESULTS_DIR="${TF_DIR}/results"
+TMP_DIR="${TF_DIR}/.tmp"
+ACTIVE_CONFIG="${TF_DIR}/config/active_config.sh"
 
 # shellcheck disable=SC2034
 source "${SCRIPT_DIR}/_log.sh"
@@ -52,7 +53,7 @@ load_active_config() {
 }
 
 get_first_client_ip() {
-  FIRST_CLIENT_IP=$(grep ssh "${SCRIPT_DIR}/login.sh" | awk '{print $4}')
+  FIRST_CLIENT_IP="$(grep ssh "${SCRIPT_DIR}/login.sh" | awk '{print $4}')"
   log.debug "FIRST_CLIENT_IP=${FIRST_CLIENT_IP}"
 }
 

--- a/terraform/examples/io500/bin/start.sh
+++ b/terraform/examples/io500/bin/start.sh
@@ -28,13 +28,13 @@ trap 'echo "Hit an unexpected and unchecked error. Exiting."' ERR
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 SCRIPT_FILENAME=$(basename "${BASH_SOURCE[0]}")
-TMP_DIR=$(realpath "${SCRIPT_DIR}/../.tmp")
+TF_DIR="$(realpath "${SCRIPT_DIR}/../")"
+IMAGES_DIR="${TF_DIR}/images"
+CLIENT_FILES_DIR="${TF_DIR}/client_files"
+TMP_DIR="${TF_DIR}/.tmp"
 SSH_CONFIG_FILE="${TMP_DIR}/ssh_config"
-TF_DIR=$(realpath "${SCRIPT_DIR}/../")
-IMAGES_DIR=$(realpath "${SCRIPT_DIR}/../images")
-CLIENT_FILES_DIR=$(realpath "${SCRIPT_DIR}/../client_files")
+CONFIG_DIR="${TF_DIR}/config"
 
-CONFIG_DIR=$(realpath "${SCRIPT_DIR}/../config")
 DEFAULT_CONFIG_FILE="GCP-1C-1S8d-rf0.sh"
 : "${CONFIG_FILE:="${DEFAULT_CONFIG_FILE}"}"
 

--- a/terraform/examples/io500/bin/stop.sh
+++ b/terraform/examples/io500/bin/stop.sh
@@ -17,10 +17,11 @@ set -eo pipefail
 trap 'echo "Hit an unexpected and unchecked error. Exiting."' ERR
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
-TMP_DIR=$(realpath "${SCRIPT_DIR}/../.tmp")
 TF_DIR=$(realpath "${SCRIPT_DIR}/../")
-CLIENT_FILES_DIR=$(realpath "${SCRIPT_DIR}/../client_files")
-CONFIG_DIR=$(realpath "${SCRIPT_DIR}/../config")
+TMP_DIR="${TF_DIR}/.tmp"
+
+CLIENT_FILES_DIR="${TF_DIR}/client_files"
+CONFIG_DIR="${TF_DIR}/config"
 ACTIVE_CONFIG_SYMLINK="${CONFIG_DIR}/active_config.sh"
 
 # shellcheck source=_log.sh


### PR DESCRIPTION
Fixed an issue that caused scripts to fail when running from a fresh clone of the repo.

Signed-off-by: Mark Olson <115657904+mark-olson@users.noreply.github.com>
