### PR TITLE
DAOSGCP-217 Updates for DAOS v2.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Direnv
+.envrc
+
 # Local .terraform directories
 **/.terraform/
 **/.terraform/*

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,6 +1,6 @@
 plugin "google" {
   enabled = true
-  version = "0.16.1"
+  version = "0.26.0"
   source  = "github.com/terraform-linters/tflint-ruleset-google"
 }
 rule "terraform_deprecated_index" {

--- a/docs/pre-deployment_guide.md
+++ b/docs/pre-deployment_guide.md
@@ -152,6 +152,7 @@ If you are currently in Cloud Shell, you don't need to run this command.
 
 ```bash
 gcloud auth login
+gcloud auth application-default login
 ```
 
 To learn more about using the Google Cloud CLI see the various [How-to Guides](https://cloud.google.com/sdk/docs/how-to).

--- a/images/ansible_playbooks/daos.yml
+++ b/images/ansible_playbooks/daos.yml
@@ -22,7 +22,7 @@
 
   vars:
     daos_install_type: "all"
-    daos_version: "2.2.0"
+    daos_version: "2.4.0"
     daos_repo_base_url: "https://packages.daos.io"
     daos_packages_repo_file: "EL8/packages/x86_64/daos_packages.repo"
     daos_packages:
@@ -33,6 +33,7 @@
     packages:
       - clustershell
       - curl
+      - fuse
       - git
       - jq
       - patch

--- a/images/build.sh
+++ b/images/build.sh
@@ -16,7 +16,7 @@
 set -eo pipefail
 trap 'echo "Unexpected and unchecked error. Exiting."' ERR
 
-: "${DAOS_VERSION:="2.2.0"}"
+: "${DAOS_VERSION:="2.4.0"}"
 : "${DAOS_REPO_BASE_URL:="https://packages.daos.io"}"
 : "${DAOS_PACKAGES_REPO_FILE:="EL8/packages/x86_64/daos_packages.repo"}"
 : "${GCP_PROJECT:=}"

--- a/images/daos.pkr.hcl
+++ b/images/daos.pkr.hcl
@@ -134,9 +134,9 @@ build {
   provisioner "shell" {
     execute_command = "echo 'packer' | sudo -S env {{ .Vars }} {{ .Path }}"
     inline = [
+      "dnf clean packages",
       "dnf -y install epel-release",
-      "dnf -y install python3.11 python3.11-pip ansible-core",
-      "alternatives --set python3 /usr/bin/python3.11"
+      "dnf -y install ansible-core"
     ]
   }
 

--- a/terraform/examples/daos_cluster/README.md
+++ b/terraform/examples/daos_cluster/README.md
@@ -45,7 +45,7 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.5 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.54.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | 5.5.0 |
 
 ## Providers
 

--- a/terraform/examples/daos_cluster/versions.tf
+++ b/terraform/examples/daos_cluster/versions.tf
@@ -17,6 +17,9 @@
 terraform {
   required_version = ">= 0.14.5"
   required_providers {
-    google = ">= 3.54.0"
+    google = {
+      source  = "hashicorp/google"
+      version = "5.5.0"
+    }
   }
 }

--- a/terraform/examples/io500/README.md
+++ b/terraform/examples/io500/README.md
@@ -29,7 +29,7 @@ bin/login.sh
 Once logged into the first DAOS client instance run the IO500 benchmark
 
 ```bash
-./run_io500-sc22.sh
+./run_io500-sc23.sh
 ```
 
 ### Destroying the DAOS Cluster
@@ -84,7 +84,7 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.5 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.54.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | 5.5.0 |
 
 ## Providers
 
@@ -110,13 +110,14 @@ No resources.
 | <a name="input_client_instance_base_name"></a> [client\_instance\_base\_name](#input\_client\_instance\_base\_name) | Base name for DAOS client instances | `string` | `"daos-client"` | no |
 | <a name="input_client_labels"></a> [client\_labels](#input\_client\_labels) | Set of key/value label pairs to assign to daos-client instances | `any` | `{}` | no |
 | <a name="input_client_machine_type"></a> [client\_machine\_type](#input\_client\_machine\_type) | GCP machine type. ie. c2-standard-16 | `string` | `"c2-standard-16"` | no |
-| <a name="input_client_number_of_instances"></a> [client\_number\_of\_instances](#input\_client\_number\_of\_instances) | Number of daos clients to bring up | `number` | `16` | no |
+| <a name="input_client_number_of_instances"></a> [client\_number\_of\_instances](#input\_client\_number\_of\_instances) | Number of DAOS client instances | `number` | `16` | no |
 | <a name="input_client_os_disk_size_gb"></a> [client\_os\_disk\_size\_gb](#input\_client\_os\_disk\_size\_gb) | OS disk size in GB | `number` | `20` | no |
 | <a name="input_client_os_disk_type"></a> [client\_os\_disk\_type](#input\_client\_os\_disk\_type) | OS disk type ie. pd-ssd, pd-standard | `string` | `"pd-ssd"` | no |
 | <a name="input_client_os_family"></a> [client\_os\_family](#input\_client\_os\_family) | OS GCP image family | `string` | `"daos-client-io500-hpc-rocky-8"` | no |
 | <a name="input_client_os_project"></a> [client\_os\_project](#input\_client\_os\_project) | OS GCP image project name. Defaults to project\_id if null. | `string` | `null` | no |
 | <a name="input_client_preemptible"></a> [client\_preemptible](#input\_client\_preemptible) | If preemptible instances | `string` | `false` | no |
 | <a name="input_client_service_account"></a> [client\_service\_account](#input\_client\_service\_account) | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string,<br>    scopes = set(string)<br>  })</pre> | <pre>{<br>  "email": null,<br>  "scopes": [<br>    "https://www.googleapis.com/auth/devstorage.read_only",<br>    "https://www.googleapis.com/auth/logging.write",<br>    "https://www.googleapis.com/auth/monitoring.write",<br>    "https://www.googleapis.com/auth/servicecontrol",<br>    "https://www.googleapis.com/auth/service.management.readonly",<br>    "https://www.googleapis.com/auth/trace.append",<br>    "https://www.googleapis.com/auth/cloud-platform"<br>  ]<br>}</pre> | no |
+| <a name="input_client_tags"></a> [client\_tags](#input\_client\_tags) | List of network tags for DAOS client instances | `list(any)` | <pre>[<br>  "daos-server"<br>]</pre> | no |
 | <a name="input_network_name"></a> [network\_name](#input\_network\_name) | Name of the GCP network | `string` | `"default"` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The GCP region | `string` | n/a | yes |
@@ -127,7 +128,7 @@ No resources.
 | <a name="input_server_instance_base_name"></a> [server\_instance\_base\_name](#input\_server\_instance\_base\_name) | Base name for DAOS server instances | `string` | `"daos-server"` | no |
 | <a name="input_server_labels"></a> [server\_labels](#input\_server\_labels) | Set of key/value label pairs to assign to daos-server instances | `any` | `{}` | no |
 | <a name="input_server_machine_type"></a> [server\_machine\_type](#input\_server\_machine\_type) | GCP machine type. ie. e2-medium | `string` | `"n2-custom-36-215040"` | no |
-| <a name="input_server_number_of_instances"></a> [server\_number\_of\_instances](#input\_server\_number\_of\_instances) | Number of daos servers to bring up | `number` | `4` | no |
+| <a name="input_server_number_of_instances"></a> [server\_number\_of\_instances](#input\_server\_number\_of\_instances) | Number of DAOS server instances | `number` | `4` | no |
 | <a name="input_server_os_disk_size_gb"></a> [server\_os\_disk\_size\_gb](#input\_server\_os\_disk\_size\_gb) | OS disk size in GB | `number` | `20` | no |
 | <a name="input_server_os_disk_type"></a> [server\_os\_disk\_type](#input\_server\_os\_disk\_type) | OS disk type ie. pd-ssd, pd-standard | `string` | `"pd-ssd"` | no |
 | <a name="input_server_os_family"></a> [server\_os\_family](#input\_server\_os\_family) | OS GCP image family | `string` | `"daos-server-io500-hpc-rocky-8"` | no |
@@ -135,6 +136,7 @@ No resources.
 | <a name="input_server_pools"></a> [server\_pools](#input\_server\_pools) | List of pools and containers to be created | <pre>list(object({<br>    name       = string<br>    size       = string<br>    tier_ratio = number<br>    user       = string<br>    group      = string<br>    acls       = list(string)<br>    properties = map(any)<br>    containers = list(object({<br>      name            = string<br>      type            = string<br>      user            = string<br>      group           = string<br>      acls            = list(string)<br>      properties      = map(any)<br>      user_attributes = map(any)<br>    }))<br>  }))</pre> | `[]` | no |
 | <a name="input_server_preemptible"></a> [server\_preemptible](#input\_server\_preemptible) | If preemptible instances | `string` | `false` | no |
 | <a name="input_server_service_account"></a> [server\_service\_account](#input\_server\_service\_account) | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string,<br>    scopes = set(string)<br>  })</pre> | <pre>{<br>  "email": null,<br>  "scopes": [<br>    "https://www.googleapis.com/auth/devstorage.read_only",<br>    "https://www.googleapis.com/auth/logging.write",<br>    "https://www.googleapis.com/auth/monitoring.write",<br>    "https://www.googleapis.com/auth/servicecontrol",<br>    "https://www.googleapis.com/auth/service.management.readonly",<br>    "https://www.googleapis.com/auth/trace.append",<br>    "https://www.googleapis.com/auth/cloud-platform"<br>  ]<br>}</pre> | no |
+| <a name="input_server_tags"></a> [server\_tags](#input\_server\_tags) | List of network tags for DAOS server instances | `list(any)` | <pre>[<br>  "daos-client"<br>]</pre> | no |
 | <a name="input_subnetwork_name"></a> [subnetwork\_name](#input\_subnetwork\_name) | Name of the GCP sub-network | `string` | `"default"` | no |
 | <a name="input_subnetwork_project"></a> [subnetwork\_project](#input\_subnetwork\_project) | The GCP project where the subnetwork is defined | `string` | `null` | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | The GCP zone | `string` | n/a | yes |

--- a/terraform/examples/io500/bin/get_io500_result_data.sh
+++ b/terraform/examples/io500/bin/get_io500_result_data.sh
@@ -14,14 +14,14 @@
 # limitations under the License.
 
 
-# Each time the run_io500-sc22.sh script is run on the first DAOS client
+# Each time the run_io500-sc23.sh script is run on the first DAOS client
 # it generates a tar.gz file that contains the result files from the run.
 # This script will download the tar.gz files for all runs and store them in
 # a the terraform/examples/io500/results directory on your local system.
 # If the terraform/examples/io500/results directory doesn't exsist, it will be
 # created.
 #
-# After running the run_io500-sc22.sh script on the first DAOS client instance, log
+# After running the run_io500-sc23.sh script on the first DAOS client instance, log
 # out of the first client instance and run this script before
 # running stop.sh. This will save the results locally so that you can view
 # them after the cluster is destroyed.

--- a/terraform/examples/io500/bin/start.sh
+++ b/terraform/examples/io500/bin/start.sh
@@ -210,6 +210,14 @@ load_config() {
     DAOS_CLIENT_BASE_NAME="${RESOURCE_PREFIX}-${DAOS_CLIENT_BASE_NAME}"
   fi
 
+if [[ -z $DAOS_SERVER_TAGS ]]; then
+  DAOS_SERVER_TAGS='["daos-server"]'
+fi
+
+if [[ -z $DAOS_CLIENT_TAGS ]]; then
+  DAOS_CLIENT_TAGS='["daos-client"]'
+fi
+
   # shellcheck disable=SC2046
   {
     export $(compgen -v | grep "^DAOS_")
@@ -306,6 +314,7 @@ server_gvnic                = ${DAOS_SERVER_GVNIC}
 server_instance_base_name   = "${DAOS_SERVER_BASE_NAME}"
 server_machine_type         = "${DAOS_SERVER_MACHINE_TYPE}"
 server_number_of_instances  = ${DAOS_SERVER_INSTANCE_COUNT}
+server_tags                 = ${DAOS_SERVER_TAGS}
 server_os_family            = "${DAOS_SERVER_IMAGE_FAMILY}"
 server_os_project           = "${GCP_PROJECT_ID}"
 
@@ -314,6 +323,7 @@ client_gvnic               = ${DAOS_CLIENT_GVNIC}
 client_instance_base_name  = "${DAOS_CLIENT_BASE_NAME}"
 client_machine_type        = "${DAOS_CLIENT_MACHINE_TYPE}"
 client_number_of_instances = ${DAOS_CLIENT_INSTANCE_COUNT}
+client_tags                = ${DAOS_CLIENT_TAGS}
 client_os_family           = "${DAOS_CLIENT_IMAGE_FAMILY}"
 client_os_project          = "${GCP_PROJECT_ID}"
 
@@ -549,7 +559,7 @@ To run the IO500 benchmark:
    bin/login.sh
 
 2. Run IO500
-   ./run_io500-sc22.sh
+   ./run_io500-sc23.sh
 
 EOF
 }

--- a/terraform/examples/io500/client_files/io500-sc23.config-template.daos-rf0.ini
+++ b/terraform/examples/io500/client_files/io500-sc23.config-template.daos-rf0.ini
@@ -1,5 +1,5 @@
 #
-# io500-sc22.config-template.daos-rf0.ini
+# io500-sc23.config-template.daos-rf0.ini
 #
 
 [global]

--- a/terraform/examples/io500/client_files/io500-sc23.config-template.daos-rf1.ini
+++ b/terraform/examples/io500/client_files/io500-sc23.config-template.daos-rf1.ini
@@ -1,5 +1,5 @@
 #
-# io500-sc22.config-template.daos-rf2.ini
+# io500-sc23.config-template.daos-rf1.ini
 #
 
 [global]
@@ -18,29 +18,33 @@ scc = FALSE
 stonewall-time = $IO500_STONEWALL_TIME
 
 [ior-easy]
-API = DFS --dfs.pool=$DAOS_POOL --dfs.cont=$DAOS_CONT --dfs.dir_oclass=RP_3G1 --dfs.oclass=EC_8P2GX
-blockSize = 99200000m
+API = DFS --dfs.pool=$DAOS_POOL --dfs.cont=$DAOS_CONT --dfs.dir_oclass=RP_2G1 --dfs.oclass=EC_8P1GX
+blockSize = 99000000m
 filePerProc = FALSE
 run = TRUE
-transferSize = 1m
+transferSize = 4m
 uniqueDir = FALSE
 verbosity =
 
 [mdtest-easy]
-API = DFS --dfs.pool=$DAOS_POOL --dfs.cont=$DAOS_CONT --dfs.dir_oclass=RP_3GX --dfs.oclass=RP_3G1
+API = DFS --dfs.pool=$DAOS_POOL --dfs.cont=$DAOS_CONT --dfs.dir_oclass=RP_2GX --dfs.oclass=RP_2G1
 n = 10000000
 run = TRUE
 
 [timestamp]
 
+[find-easy]
+nproc = $NPROC
+run = FALSE
+
 [ior-hard]
-API = DFS --dfs.pool=$DAOS_POOL --dfs.cont=$DAOS_CONT --dfs.dir_oclass=RP_3G1 --dfs.oclass=RP_3GX --dfs.chunk_size=470080
+API = DFS --dfs.pool=$DAOS_POOL --dfs.cont=$DAOS_CONT --dfs.dir_oclass=RP_2G1 --dfs.oclass=RP_2GX --dfs.chunk_size=470080
+run = TRUE
 segmentCount = 10000000
 verbosity =
-run = TRUE
 
 [mdtest-hard]
-API = DFS --dfs.pool=$DAOS_POOL --dfs.cont=$DAOS_CONT --dfs.dir_oclass=RP_3GX --dfs.oclass=RP_3G1
+API = DFS --dfs.pool=$DAOS_POOL --dfs.cont=$DAOS_CONT --dfs.dir_oclass=RP_2GX --dfs.oclass=RP_2G1
 n = 10000000
 files-per-dir =
 run = TRUE
@@ -48,10 +52,6 @@ run = TRUE
 [find]
 nproc = $NPROC
 run = TRUE
-
-[find-easy]
-nproc = $NPROC
-run = FALSE
 
 [find-hard]
 nproc = $NPROC

--- a/terraform/examples/io500/client_files/io500-sc23.config-template.daos-rf2.ini
+++ b/terraform/examples/io500/client_files/io500-sc23.config-template.daos-rf2.ini
@@ -1,5 +1,5 @@
 #
-# io500-sc22.config-template.daos-rf1.ini
+# io500-sc23.config-template.daos-rf2.ini
 #
 
 [global]
@@ -18,33 +18,29 @@ scc = FALSE
 stonewall-time = $IO500_STONEWALL_TIME
 
 [ior-easy]
-API = DFS --dfs.pool=$DAOS_POOL --dfs.cont=$DAOS_CONT --dfs.dir_oclass=RP_2G1 --dfs.oclass=EC_8P1GX
-blockSize = 99000000m
+API = DFS --dfs.pool=$DAOS_POOL --dfs.cont=$DAOS_CONT --dfs.dir_oclass=RP_3G1 --dfs.oclass=EC_8P2GX
+blockSize = 99200000m
 filePerProc = FALSE
 run = TRUE
-transferSize = 4m
+transferSize = 1m
 uniqueDir = FALSE
 verbosity =
 
 [mdtest-easy]
-API = DFS --dfs.pool=$DAOS_POOL --dfs.cont=$DAOS_CONT --dfs.dir_oclass=RP_2GX --dfs.oclass=RP_2G1
+API = DFS --dfs.pool=$DAOS_POOL --dfs.cont=$DAOS_CONT --dfs.dir_oclass=RP_3GX --dfs.oclass=RP_3G1
 n = 10000000
 run = TRUE
 
 [timestamp]
 
-[find-easy]
-nproc = $NPROC
-run = FALSE
-
 [ior-hard]
-API = DFS --dfs.pool=$DAOS_POOL --dfs.cont=$DAOS_CONT --dfs.dir_oclass=RP_2G1 --dfs.oclass=RP_2GX --dfs.chunk_size=470080
-run = TRUE
+API = DFS --dfs.pool=$DAOS_POOL --dfs.cont=$DAOS_CONT --dfs.dir_oclass=RP_3G1 --dfs.oclass=RP_3GX --dfs.chunk_size=470080
 segmentCount = 10000000
 verbosity =
+run = TRUE
 
 [mdtest-hard]
-API = DFS --dfs.pool=$DAOS_POOL --dfs.cont=$DAOS_CONT --dfs.dir_oclass=RP_2GX --dfs.oclass=RP_2G1
+API = DFS --dfs.pool=$DAOS_POOL --dfs.cont=$DAOS_CONT --dfs.dir_oclass=RP_3GX --dfs.oclass=RP_3G1
 n = 10000000
 files-per-dir =
 run = TRUE
@@ -52,6 +48,10 @@ run = TRUE
 [find]
 nproc = $NPROC
 run = TRUE
+
+[find-easy]
+nproc = $NPROC
+run = FALSE
 
 [find-hard]
 nproc = $NPROC

--- a/terraform/examples/io500/client_files/io500_summary_to_csv.py
+++ b/terraform/examples/io500/client_files/io500_summary_to_csv.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# Copyright 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import csv
+import sys
+import os
+
+# Function to parse the main results into CSV format
+def parse_results_to_csv(script_output):
+    header = ['Test', 'Value', 'Unit', 'Time (seconds)']
+    parsed_data = []
+    parsed_data.append(header)
+
+    # Use regular expression to find all relevant lines for results
+    pattern = re.compile(r"\[RESULT\].*?(\w+(?:-\w+)+)\s+([\d.]+)\s+(GiB/s|kIOPS)\s+:\s+time\s+([\d.]+)")
+
+    # Find all matches and add them to the parsed_data list
+    for match in pattern.finditer(script_output):
+        test, value, unit, time = match.groups()
+        parsed_data.append([test, value, unit, time])
+
+    return parsed_data
+
+# Function to parse the score line into CSV format
+def parse_score_to_csv(last_line):
+    # Use regular expression to extract score components
+    score_pattern = re.compile(r"Bandwidth\s+([\d.]+)\s+(GiB/s)\s+:\s+IOPS\s+([\d.]+)\s+(kiops)")
+    score_match = score_pattern.search(last_line)
+    if score_match:
+        bandwidth, bandwidth_unit, iops, iops_unit = score_match.groups()
+        return [
+            ['Score', 'Value', 'Unit'],
+            ['Bandwidth', bandwidth, bandwidth_unit],
+            ['IOPS', iops, iops_unit]
+        ]
+    return []
+
+# Function to parse the total value into CSV format
+def parse_total_to_csv(last_line):
+    # Use regular expression to extract total value
+    total_pattern = re.compile(r"TOTAL\s+([\d.]+)")
+    total_match = total_pattern.search(last_line)
+    if total_match:
+        total_value = total_match.group(1)
+        return [['Total'], [total_value]]
+    return []
+
+# Main function to handle file operations
+def main(file_path):
+    print(f"file_path = {file_path}")
+    results_dir = os.path.dirname(file_path)
+    summary_file = os.path.basename(file_path)
+    with open(file_path, 'r') as file:
+        lines = file.readlines()
+
+    # The last line contains the score and total
+    last_line = lines[-1]
+
+    # Parse the results, score, and total
+    results_data = parse_results_to_csv(''.join(lines))
+    score_data = parse_score_to_csv(last_line)
+    total_data = parse_total_to_csv(last_line)
+
+    # Derive the CSV filenames
+    base_filename = summary_file.replace('.txt', '')
+    results_csv_filename = f"{results_dir}/daos_io500_{base_filename}.csv"
+    score_csv_filename = f"{results_dir}/daos_io500_score.csv"
+    total_csv_filename = f"{results_dir}/daos_io500_total.csv"
+
+    # Write the results summary CSV file
+    with open(results_csv_filename, 'w', newline='') as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerows(results_data)
+
+    # Write the score CSV file
+    with open(score_csv_filename, 'w', newline='') as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerows(score_data)
+
+    # Write the total CSV file
+    with open(total_csv_filename, 'w', newline='') as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerows(total_data)
+
+    print(f"Created CSV files:")
+    print(results_csv_filename)
+    print(score_csv_filename)
+    print(total_csv_filename)
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python3 script.py <file_path>")
+        sys.exit(1)
+    input_file_path = sys.argv[1]
+    print(f"input_file_path = {input_file_path}")
+    main(input_file_path)

--- a/terraform/examples/io500/client_files/run_io500-sc23.sh
+++ b/terraform/examples/io500/client_files/run_io500-sc23.sh
@@ -17,7 +17,7 @@
 # Cleans DAOS storage and runs an IO500 benchmark
 #
 # Instructions that were referenced to create this script are at
-# https://daosio.atlassian.net/wiki/spaces/DC/pages/11167301633/IO-500+SC22
+# https://daosio.atlassian.net/wiki/spaces/DC/pages/11167301633/IO-500+sc23
 #
 
 set -eo pipefail
@@ -28,7 +28,7 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 # shellcheck source=_log.sh
 source "${SCRIPT_DIR}/_log.sh"
 
-IO500_VERSION_TAG="io500-sc22"
+IO500_VERSION_TAG="io500-sc23"
 CONFIG_FILE="${SCRIPT_DIR}/config.sh"
 
 # Comma separated list of servers needed for the dmg command
@@ -121,29 +121,18 @@ show_storage_usage() {
   dmg storage query usage
 }
 
-use_old_cli() {
-  local daos_version
-  daos_version=$(rpm -q --queryformat '%{VERSION}' daos)
-  awk 'BEGIN{if(ARGV[1]<ARGV[2])exit 0;exit 1;}' "${daos_version}" "2.3"
-  return $?
-}
-
 create_pool() {
-  local daos_version
-  daos_version=$(dmg version | awk '{print $3}')
-
   log.info "Create pool: label=${DAOS_POOL_LABEL} size=${DAOS_POOL_SIZE}"
 
   if ! dmg pool list | grep -q "${DAOS_POOL_LABEL}"; then
-    if use_old_cli; then
-      # dmg options are different in different versions of DAOS
-      # Use older DAOS v2.2.x dmg options
-      dmg pool create --size="${DAOS_POOL_SIZE}"\
-        --tier-ratio="${DAOS_TIER_RATIO}" \
+    if [[ "${DAOS_POOL_SIZE}" == "100%" ]]; then
+      dmg pool create \
+        --size="${DAOS_POOL_SIZE}" \
         --user="${USER}" \
-        --label="${DAOS_POOL_LABEL}"
+        "${DAOS_POOL_LABEL}"
     else
-      dmg pool create --size="${DAOS_POOL_SIZE}"\
+      dmg pool create \
+        --size="${DAOS_POOL_SIZE}"\
         --tier-ratio="${DAOS_TIER_RATIO}" \
         --user="${USER}" \
         "${DAOS_POOL_LABEL}"
@@ -151,12 +140,7 @@ create_pool() {
   fi
 
   log.info "Setting pool property: reclaim=disabled"
-  if use_old_cli; then
-    # Use older DAOS v2.2.x dmg options
-    dmg pool set-prop "${DAOS_POOL_LABEL}" --name=reclaim --value=disabled
-  else
     dmg pool set-prop "${DAOS_POOL_LABEL}" "reclaim:disabled"
-  fi
 
   log.info "Pool created successfully"
   dmg pool query "${DAOS_POOL_LABEL}"
@@ -166,20 +150,11 @@ create_container() {
   log.info "Create container: label=${DAOS_CONT_LABEL}"
 
   if ! daos container list "${DAOS_POOL_LABEL}" | grep -q "${DAOS_CONT_LABEL}"; then
-    if use_old_cli; then
-      # Use older DAOS v2.2.x dmg options
-      daos container create --type=POSIX \
-        --chunk-size="${DAOS_CHUNK_SIZE}" \
-        --properties="${DAOS_CONT_REPLICATION_FACTOR}" \
-        --label="${DAOS_CONT_LABEL}" \
-        "${DAOS_POOL_LABEL}"
-    else
-      daos container create --type=POSIX \
-        --chunk-size="${DAOS_CHUNK_SIZE}" \
-        --properties="${DAOS_CONT_REPLICATION_FACTOR}" \
-        "${DAOS_POOL_LABEL}" \
-        "${DAOS_CONT_LABEL}"
-    fi
+    daos container create --type=POSIX \
+      --chunk-size="${DAOS_CHUNK_SIZE}" \
+      --properties="${DAOS_CONT_REPLICATION_FACTOR}" \
+      "${DAOS_POOL_LABEL}" \
+      "${DAOS_CONT_LABEL}"
   fi
 
   log.info "Show container properties"
@@ -306,8 +281,12 @@ process_results() {
   dmg pool query "${DAOS_POOL_LABEL}" > \
     "${IO500_RESULTS_DIR_TIMESTAMPED}/dmg_pool_query_${DAOS_POOL_LABEL}.txt"
 
-  log.info "Results files located in ${IO500_RESULTS_DIR_TIMESTAMPED}"
+  # Convert summary txt to csv
+  log.info "Converting result_summary.txt to csv"
+  result_summary_file=$(find "${IO500_RESULTS_DIR_TIMESTAMPED}" -type f -name "result_summary.txt")
+  "${SCRIPT_DIR}/io500_summary_to_csv.py" "${result_summary_file}"
 
+  log.info "Results files located in ${IO500_RESULTS_DIR_TIMESTAMPED}"
   RESULTS_TAR_FILE="${IO500_TEST_CONFIG_ID}_${TIMESTAMP}.tar.gz"
 
   log.info "Creating '${HOME}/${RESULTS_TAR_FILE}' file with contents of ${IO500_RESULTS_DIR_TIMESTAMPED} directory"

--- a/terraform/examples/io500/config/GCP-10C-4S16d-rf0.sh
+++ b/terraform/examples/io500/config/GCP-10C-4S16d-rf0.sh
@@ -17,7 +17,7 @@
 
 # ------------------------------------------------------------------------------
 # Configuration: 10 clients, 4 servers, 16 disks per server
-# IO500 Config:  io500-sc22.config-template.daos-rf0.ini
+# IO500 Config:  io500-sc23.config-template.daos-rf0.ini
 # ------------------------------------------------------------------------------
 
 # Set if you want to prepend a string to the names of the instances
@@ -45,14 +45,14 @@ DAOS_CLIENT_GVNIC=false
 DAOS_CLIENT_IMAGE_FAMILY="daos-client-io500-hpc-rocky-8"
 
 # Storage
-DAOS_POOL_SIZE="$(awk -v disk_count=${DAOS_SERVER_DISK_COUNT} -v server_count=${DAOS_SERVER_INSTANCE_COUNT} 'BEGIN {pool_size = 375 * disk_count * server_count / 1000; print pool_size"TB"}')"
+DAOS_POOL_SIZE="100%"
 DAOS_CONT_REPLICATION_FACTOR="rf:0"
 DAOS_CHUNK_SIZE="1048576" # 1MB
 
 # IO500
 IO500_TEST_CONFIG_ID="GCP-10C-4S16d-rf0"
 IO500_STONEWALL_TIME=60 # Number of seconds to run the benchmark
-IO500_INI="io500-sc22.config-template.daos-rf0.ini"
+IO500_INI="io500-sc23.config-template.daos-rf0.ini"
 
 # GCP
 GCP_PROJECT_ID=$(gcloud info --format="value(config.project)")

--- a/terraform/examples/io500/config/GCP-16C-4S16d-rf0.sh
+++ b/terraform/examples/io500/config/GCP-16C-4S16d-rf0.sh
@@ -17,7 +17,7 @@
 
 # ------------------------------------------------------------------------------
 # Configuration: 10 clients, 4 servers, 16 disks per server
-# IO500 Config:  io500-sc22.config-template.daos-rf0.ini
+# IO500 Config:  io500-sc23.config-template.daos-rf0.ini
 # ------------------------------------------------------------------------------
 
 # Set if you want to prepend a string to the names of the instances
@@ -45,14 +45,14 @@ DAOS_CLIENT_GVNIC=false
 DAOS_CLIENT_IMAGE_FAMILY="daos-client-io500-hpc-rocky-8"
 
 # Storage
-DAOS_POOL_SIZE="$(awk -v disk_count=${DAOS_SERVER_DISK_COUNT} -v server_count=${DAOS_SERVER_INSTANCE_COUNT} 'BEGIN {pool_size = 375 * disk_count * server_count / 1000; print pool_size"TB"}')"
+DAOS_POOL_SIZE="100%"
 DAOS_CONT_REPLICATION_FACTOR="rf:0"
 DAOS_CHUNK_SIZE="1048576" # 1MB
 
 # IO500
 IO500_TEST_CONFIG_ID="GCP-16C-4S16d-rf0"
 IO500_STONEWALL_TIME=60 # Number of seconds to run the benchmark
-IO500_INI="io500-sc22.config-template.daos-rf0.ini"
+IO500_INI="io500-sc23.config-template.daos-rf0.ini"
 
 # GCP
 GCP_PROJECT_ID=$(gcloud info --format="value(config.project)")

--- a/terraform/examples/io500/config/GCP-1C-1S8d-rf0.sh
+++ b/terraform/examples/io500/config/GCP-1C-1S8d-rf0.sh
@@ -17,7 +17,7 @@
 
 # ------------------------------------------------------------------------------
 # Configuration: 1 client, 1 server, 8 disks per server
-# IO500 Config:  io500-sc22.config-template.daos-rf0.ini
+# IO500 Config:  io500-sc23.config-template.daos-rf0.ini
 # ------------------------------------------------------------------------------
 
 # Set if you want to prepend a string to the names of the instances
@@ -45,14 +45,14 @@ DAOS_CLIENT_GVNIC=false
 DAOS_CLIENT_IMAGE_FAMILY="daos-client-io500-hpc-rocky-8"
 
 # Storage
-DAOS_POOL_SIZE="$(awk -v disk_count=${DAOS_SERVER_DISK_COUNT} -v server_count=${DAOS_SERVER_INSTANCE_COUNT} 'BEGIN {pool_size = 375 * disk_count * server_count / 1000; print pool_size"TB"}')"
+DAOS_POOL_SIZE="100%"
 DAOS_CONT_REPLICATION_FACTOR="rf:0"
 DAOS_CHUNK_SIZE="1048576" # 1MB
 
 # IO500
 IO500_TEST_CONFIG_ID="GCP-1C-1S8d-rf0"
 IO500_STONEWALL_TIME=60 # Number of seconds to run the benchmark
-IO500_INI="io500-sc22.config-template.daos-rf0.ini"
+IO500_INI="io500-sc23.config-template.daos-rf0.ini"
 
 # GCP
 GCP_PROJECT_ID=$(gcloud info --format="value(config.project)")

--- a/terraform/examples/io500/config/GCP-2C-1S8d-rf0.sh
+++ b/terraform/examples/io500/config/GCP-2C-1S8d-rf0.sh
@@ -17,7 +17,7 @@
 
 # ------------------------------------------------------------------------------
 # Configuration: 2 clients, 1 server, 8 disks per server
-# IO500 Config:  io500-sc22.config-template.daos-rf0.ini
+# IO500 Config:  io500-sc23.config-template.daos-rf0.ini
 # ------------------------------------------------------------------------------
 
 # Set if you want to prepend a string to the names of the instances
@@ -45,14 +45,14 @@ DAOS_CLIENT_GVNIC=false
 DAOS_CLIENT_IMAGE_FAMILY="daos-client-io500-hpc-rocky-8"
 
 # Storage
-DAOS_POOL_SIZE="$(awk -v disk_count=${DAOS_SERVER_DISK_COUNT} -v server_count=${DAOS_SERVER_INSTANCE_COUNT} 'BEGIN {pool_size = 375 * disk_count * server_count / 1000; print pool_size"TB"}')"
+DAOS_POOL_SIZE="100%"
 DAOS_CONT_REPLICATION_FACTOR="rf:0"
 DAOS_CHUNK_SIZE="1048576" # 1MB
 
 # IO500
 IO500_TEST_CONFIG_ID="GCP-2C-1S8d-rf0"
 IO500_STONEWALL_TIME=60 # Number of seconds to run the benchmark
-IO500_INI="io500-sc22.config-template.daos-rf0.ini"
+IO500_INI="io500-sc23.config-template.daos-rf0.ini"
 
 # GCP
 GCP_PROJECT_ID=$(gcloud info --format="value(config.project)")

--- a/terraform/examples/io500/config/GCP-32C-10S16d-rf2.sh
+++ b/terraform/examples/io500/config/GCP-32C-10S16d-rf2.sh
@@ -17,7 +17,7 @@
 
 # ------------------------------------------------------------------------------
 # Configuration: 32 clients, 10 servers, 16 disks per server
-# IO500 Config:  io500-sc22.config-template.daos-rf2.ini
+# IO500 Config:  io500-sc23.config-template.daos-rf2.ini
 # ------------------------------------------------------------------------------
 # Set if you want to prepend a string to the names of the instances
 : "${RESOURCE_PREFIX:=}"
@@ -44,14 +44,14 @@ DAOS_CLIENT_GVNIC=false
 DAOS_CLIENT_IMAGE_FAMILY="daos-client-io500-hpc-rocky-8"
 
 # Storage
-DAOS_POOL_SIZE="$(awk -v disk_count=${DAOS_SERVER_DISK_COUNT} -v server_count=${DAOS_SERVER_INSTANCE_COUNT} 'BEGIN {pool_size = 375 * disk_count * server_count / 1000; print pool_size"TB"}')"
+DAOS_POOL_SIZE="100%"
 DAOS_CONT_REPLICATION_FACTOR="rf:2"
 DAOS_CHUNK_SIZE="1048576" # 1MB
 
 # IO500
 IO500_TEST_CONFIG_ID="GCP-32C-10S16d-rf2"
 IO500_STONEWALL_TIME=60 # Number of seconds to run the benchmark
-IO500_INI="io500-sc22.config-template.daos-rf2.ini"
+IO500_INI="io500-sc23.config-template.daos-rf2.ini"
 
 # GCP
 GCP_PROJECT_ID=$(gcloud info --format="value(config.project)")

--- a/terraform/examples/io500/config/GCP-32C-8S16d-rf0.sh
+++ b/terraform/examples/io500/config/GCP-32C-8S16d-rf0.sh
@@ -17,7 +17,7 @@
 
 # ------------------------------------------------------------------------------
 # Configuration: 32 clients, 8 servers, 16 disks per server
-# IO500 Config:  io500-sc22.config-template.daos-rf0.ini
+# IO500 Config:  io500-sc23.config-template.daos-rf0.ini
 # ------------------------------------------------------------------------------
 
 # Set if you want to prepend a string to the names of the instances
@@ -45,14 +45,14 @@ DAOS_CLIENT_GVNIC=false
 DAOS_CLIENT_IMAGE_FAMILY="daos-client-io500-hpc-rocky-8"
 
 # Storage
-DAOS_POOL_SIZE="$(awk -v disk_count=${DAOS_SERVER_DISK_COUNT} -v server_count=${DAOS_SERVER_INSTANCE_COUNT} 'BEGIN {pool_size = 375 * disk_count * server_count / 1000; print pool_size"TB"}')"
+DAOS_POOL_SIZE="100%"
 DAOS_CONT_REPLICATION_FACTOR="rf:0"
 DAOS_CHUNK_SIZE="1048576" # 1MB
 
 # IO500
 IO500_TEST_CONFIG_ID="GCP-32C-8S16d-rf0"
 IO500_STONEWALL_TIME=60 # Number of seconds to run the benchmark
-IO500_INI="io500-sc22.config-template.daos-rf0.ini"
+IO500_INI="io500-sc23.config-template.daos-rf0.ini"
 
 # GCP
 GCP_PROJECT_ID=$(gcloud info --format="value(config.project)")

--- a/terraform/examples/io500/config/GCP-32C-9S16d-rf1.sh
+++ b/terraform/examples/io500/config/GCP-32C-9S16d-rf1.sh
@@ -17,7 +17,7 @@
 
 # ------------------------------------------------------------------------------
 # Configuration: 32 clients, 9 servers, 16 disks per server
-# IO500 Config:  io500-sc22.config-template.daos-rf1.ini
+# IO500 Config:  io500-sc23.config-template.daos-rf1.ini
 # ------------------------------------------------------------------------------
 # Set if you want to prepend a string to the names of the instances
 : "${RESOURCE_PREFIX:=}"
@@ -44,14 +44,14 @@ DAOS_CLIENT_GVNIC=false
 DAOS_CLIENT_IMAGE_FAMILY="daos-client-io500-hpc-rocky-8"
 
 # Storage
-DAOS_POOL_SIZE="$(awk -v disk_count=${DAOS_SERVER_DISK_COUNT} -v server_count=${DAOS_SERVER_INSTANCE_COUNT} 'BEGIN {pool_size = 375 * disk_count * server_count / 1000; print pool_size"TB"}')"
+DAOS_POOL_SIZE="100%"
 DAOS_CONT_REPLICATION_FACTOR="rf:1"
 DAOS_CHUNK_SIZE="1048576" # 1MB
 
 # IO500
 IO500_TEST_CONFIG_ID="GCP-32C-9S16d-rf1"
 IO500_STONEWALL_TIME=60 # Number of seconds to run the benchmark
-IO500_INI="io500-sc22.config-template.daos-rf1.ini"
+IO500_INI="io500-sc23.config-template.daos-rf1.ini"
 
 # GCP
 GCP_PROJECT_ID=$(gcloud info --format="value(config.project)")

--- a/terraform/examples/io500/config/GCP-4C-1S8d-rf0.sh
+++ b/terraform/examples/io500/config/GCP-4C-1S8d-rf0.sh
@@ -17,7 +17,7 @@
 
 # ------------------------------------------------------------------------------
 # Configuration: 4 clients, 1 server, 8 disks per server
-# IO500 Config:  io500-sc22.config-template.daos-rf0.ini
+# IO500 Config:  io500-sc23.config-template.daos-rf0.ini
 # ------------------------------------------------------------------------------
 
 # Set if you want to prepend a string to the names of the instances
@@ -45,14 +45,14 @@ DAOS_CLIENT_GVNIC=false
 DAOS_CLIENT_IMAGE_FAMILY="daos-client-io500-hpc-rocky-8"
 
 # Storage
-DAOS_POOL_SIZE="$(awk -v disk_count=${DAOS_SERVER_DISK_COUNT} -v server_count=${DAOS_SERVER_INSTANCE_COUNT} 'BEGIN {pool_size = 375 * disk_count * server_count / 1000; print pool_size"TB"}')"
+DAOS_POOL_SIZE="100%"
 DAOS_CONT_REPLICATION_FACTOR="rf:0"
 DAOS_CHUNK_SIZE="1048576" # 1MB
 
 # IO500
 IO500_TEST_CONFIG_ID="GCP-4C-1S8d-rf0"
 IO500_STONEWALL_TIME=60 # Number of seconds to run the benchmark
-IO500_INI="io500-sc22.config-template.daos-rf0.ini"
+IO500_INI="io500-sc23.config-template.daos-rf0.ini"
 
 # GCP
 GCP_PROJECT_ID=$(gcloud info --format="value(config.project)")

--- a/terraform/examples/io500/config/GCP-8C-2S16d-rf0.sh
+++ b/terraform/examples/io500/config/GCP-8C-2S16d-rf0.sh
@@ -17,7 +17,7 @@
 
 # ------------------------------------------------------------------------------
 # Configuration: 8 clients, 2 servers, 16 disks per server
-# IO500 Config:  io500-sc22.config-template.daos-rf0.ini
+# IO500 Config:  io500-sc23.config-template.daos-rf0.ini
 # ------------------------------------------------------------------------------
 
 # Set if you want to prepend a string to the names of the instances
@@ -45,14 +45,14 @@ DAOS_CLIENT_GVNIC=false
 DAOS_CLIENT_IMAGE_FAMILY="daos-client-io500-hpc-rocky-8"
 
 # Storage
-DAOS_POOL_SIZE="$(awk -v disk_count=${DAOS_SERVER_DISK_COUNT} -v server_count=${DAOS_SERVER_INSTANCE_COUNT} 'BEGIN {pool_size = 375 * disk_count * server_count / 1000; print pool_size"TB"}')"
+DAOS_POOL_SIZE="100%"
 DAOS_CONT_REPLICATION_FACTOR="rf:0"
 DAOS_CHUNK_SIZE="1048576" # 1MB
 
 # IO500
 IO500_TEST_CONFIG_ID="GCP-8C-2S16d-rf0"
 IO500_STONEWALL_TIME=60 # Number of seconds to run the benchmark
-IO500_INI="io500-sc22.config-template.daos-rf0.ini"
+IO500_INI="io500-sc23.config-template.daos-rf0.ini"
 
 # GCP
 GCP_PROJECT_ID=$(gcloud info --format="value(config.project)")

--- a/terraform/examples/io500/images/README.md
+++ b/terraform/examples/io500/images/README.md
@@ -2,15 +2,13 @@
 
 This directory contains content for building DAOS Server and Client images used in IO500 benchmark runs.
 
-The `build_io500_images.sh` script makes modifications in the `images\` directory and then calls `images/build.sh` to build images.
-
-Specifically, it does the following:
+The `build_io500_images.sh` script
 
 - Copies the `terraform/examples/io500/images/ansible_playbooks/io500.yml` playbook to `images/ansible_playbooks`
 - Copies the `terraform/examples/io500/images/patches` directory to `images/`
-- Creates an `io500-daos.pkr.hcl` packer template. The template includes an additional ansible-local provisioner that runs the io500.yml playbook when building the DAOS client image.
+- Creates an `images/io500-daos.pkr.hcl` packer template. The template includes an additional ansible-local provisioner that runs the `images/ansible_playbooks/io500.yml` playbook when building the DAOS client image.
 - Calls `images/build.sh` to build the DAOS client and server images
-  - When building the client image sets the DAOS_PACKER_TEMPLATE=`io500-daos.pkr.hcl` which installs the  DAOS client image
+  - When building the client image sets the DAOS_PACKER_TEMPLATE=`io500-daos.pkr.hcl` which build the custom DAOS client image with the io500 software installed.
 
 The `build_io500_images.sh` script will build 2 images with image families:
 

--- a/terraform/examples/io500/images/ansible_playbooks/io500.yml
+++ b/terraform/examples/io500/images/ansible_playbooks/io500.yml
@@ -22,24 +22,36 @@
   become: true
 
   vars:
-    #install_io500: false
     packages:
       - bzip2-devel
       - clustershell
+      - daos-devel
+      - fuse
       - gcc-toolset-9-gcc
       - gcc-toolset-9-gcc-c++
       - git
       - jq
       - libarchive-devel
       - libuuid-devel
+      - lsof
+      - nvme-cli
       - openssl-devel
       - patch
+      - pciutils
+      - pdsh
       - rsync
+      - sudo
+      - vim
       - wget
-    oneapi_packages:
-      - intel-oneapi-mpi-2021.9.0
-      - intel-oneapi-mpi-devel-2021.9.0
-    io500_version: io500-sc22
+      - which
+
+    inteloneapi_base_url: "https://yum.repos.intel.com/oneapi"
+    inteloneapi_gpgkey_file: "GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB"
+    inteloneapi_gpgkey_url: "https://yum.repos.intel.com/intel-gpg-keys/{{ inteloneapi_gpgkey_file }}"
+    inteloneapi_packages:
+      - intel-oneapi-mpi
+      - intel-oneapi-mpi-devel
+    io500_version: io500-sc23
     io500_path: "/opt/{{ io500_version }}"
     daos_install_path: /usr
 
@@ -89,30 +101,30 @@
         content: |
           [oneAPI]
           name=Intel(R) oneAPI repository
-          baseurl=https://yum.repos.intel.com/oneapi
+          baseurl={{ inteloneapi_base_url }}
           enabled=1
           gpgcheck=1
           repo_gpgcheck=1
-          gpgkey=https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+          gpgkey={{ inteloneapi_gpgkey_url }}
 
     - name: Download GPG key
       ansible.builtin.get_url:
-        url: https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
-        dest: /tmp/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+        url: "{{ inteloneapi_gpgkey_url }}"
+        dest: "/tmp/{{ inteloneapi_gpgkey_file }}"
 
     - name: Import GPG key
       ansible.builtin.rpm_key:
-        key: /tmp/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+        key: "/tmp/{{ inteloneapi_gpgkey_file }}"
         state: present
 
     - name: Clean up key file
       ansible.builtin.file:
-        path: /tmp/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+        path: "/tmp/{{ inteloneapi_gpgkey_file }}"
         state: absent
 
     - name: Install oneAPI Packages
       ansible.builtin.package:
-        name: "{{ oneapi_packages }}"
+        name: "{{ inteloneapi_packages }}"
         state: present
 
     - name: Clone IO500 repo

--- a/terraform/examples/io500/images/patches/prepare.sh.patch
+++ b/terraform/examples/io500/images/patches/prepare.sh.patch
@@ -1,12 +1,12 @@
 diff --git a/prepare.sh b/prepare.sh
-index da39346..2198147 100755
+index 35bb555..aed4437 100755
 --- a/prepare.sh
 +++ b/prepare.sh
 @@ -8,7 +8,7 @@ echo It will output OK at the end if builds succeed
  echo
 
  IOR_HASH=06fc08e147600f4e5896a5b9b2bf8f1c4a79121f
--PFIND_HASH=62c3a7e31
+-PFIND_HASH=778dca8
 +PFIND_HASH=dfs_find
 
  INSTALL_DIR=$PWD

--- a/terraform/examples/io500/main.tf
+++ b/terraform/examples/io500/main.tf
@@ -27,6 +27,7 @@ module "daos_server" {
   subnetwork_project  = var.subnetwork_project
   subnetwork_name     = var.subnetwork_name
   number_of_instances = var.server_number_of_instances
+  tags                = var.server_tags
   labels              = var.server_labels
   preemptible         = var.server_preemptible
   instance_base_name  = var.server_instance_base_name
@@ -52,6 +53,7 @@ module "daos_client" {
   subnetwork_project    = var.subnetwork_project
   subnetwork_name       = var.subnetwork_name
   number_of_instances   = var.client_number_of_instances
+  tags                  = var.client_tags
   labels                = var.client_labels
   preemptible           = var.client_preemptible
   instance_base_name    = var.client_instance_base_name

--- a/terraform/examples/io500/variables.tf
+++ b/terraform/examples/io500/variables.tf
@@ -96,9 +96,15 @@ variable "server_instance_base_name" {
 }
 
 variable "server_number_of_instances" {
-  description = "Number of daos servers to bring up"
+  description = "Number of DAOS server instances"
   default     = 4
   type        = number
+}
+
+variable "server_tags" {
+  description = "List of network tags for DAOS server instances"
+  default     = ["daos-client"]
+  type        = list(any)
 }
 
 variable "server_daos_disk_count" {
@@ -216,9 +222,15 @@ variable "client_instance_base_name" {
 }
 
 variable "client_number_of_instances" {
-  description = "Number of daos clients to bring up"
+  description = "Number of DAOS client instances"
   default     = 16
   type        = number
+}
+
+variable "client_tags" {
+  description = "List of network tags for DAOS client instances"
+  default     = ["daos-server"]
+  type        = list(any)
 }
 
 variable "client_service_account" {

--- a/terraform/examples/io500/versions.tf
+++ b/terraform/examples/io500/versions.tf
@@ -17,6 +17,9 @@
 terraform {
   required_version = ">= 0.14.5"
   required_providers {
-    google = ">= 3.54.0"
+    google = {
+      source  = "hashicorp/google"
+      version = "5.5.0"
+    }
   }
 }

--- a/terraform/modules/daos_client/README.md
+++ b/terraform/modules/daos_client/README.md
@@ -24,15 +24,15 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.5 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.54.0 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.16.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | 5.5.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | 5.5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 3.54.0 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 4.16.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 5.5.0 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | 5.5.0 |
 
 ## Modules
 
@@ -42,9 +42,9 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [google-beta_google_compute_instance.named_instances](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_compute_instance) | resource |
-| [google_compute_disk.boot_disk](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk) | resource |
-| [google_compute_image.os_image](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
+| [google-beta_google_compute_instance.named_instances](https://registry.terraform.io/providers/hashicorp/google-beta/5.5.0/docs/resources/google_compute_instance) | resource |
+| [google_compute_disk.boot_disk](https://registry.terraform.io/providers/hashicorp/google/5.5.0/docs/resources/compute_disk) | resource |
+| [google_compute_image.os_image](https://registry.terraform.io/providers/hashicorp/google/5.5.0/docs/data-sources/compute_image) | data source |
 
 ## Inputs
 
@@ -68,6 +68,7 @@ No modules.
 | <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string,<br>    scopes = set(string)<br>  })</pre> | <pre>{<br>  "email": null,<br>  "scopes": [<br>    "https://www.googleapis.com/auth/devstorage.read_only",<br>    "https://www.googleapis.com/auth/logging.write",<br>    "https://www.googleapis.com/auth/monitoring.write",<br>    "https://www.googleapis.com/auth/servicecontrol",<br>    "https://www.googleapis.com/auth/service.management.readonly",<br>    "https://www.googleapis.com/auth/trace.append",<br>    "https://www.googleapis.com/auth/cloud-platform"<br>  ]<br>}</pre> | no |
 | <a name="input_subnetwork_name"></a> [subnetwork\_name](#input\_subnetwork\_name) | Name of the GCP sub-network to use | `string` | `"default"` | no |
 | <a name="input_subnetwork_project"></a> [subnetwork\_project](#input\_subnetwork\_project) | The GCP project where the subnetwork is defined | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | List of network tags to assign to daos-client instances | `list(any)` | <pre>[<br>  "daos-client"<br>]</pre> | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | The GCP zone to create and test resources in | `string` | n/a | yes |
 
 ## Outputs

--- a/terraform/modules/daos_client/main.tf
+++ b/terraform/modules/daos_client/main.tf
@@ -53,7 +53,7 @@ resource "google_compute_instance" "named_instances" {
   count          = var.number_of_instances
   name           = format("%s-%04d", var.instance_base_name, count.index + 1)
   can_ip_forward = false
-  tags           = ["daos-client"]
+  tags           = var.tags
   machine_type   = var.machine_type
 
   metadata = {

--- a/terraform/modules/daos_client/variables.tf
+++ b/terraform/modules/daos_client/variables.tf
@@ -29,6 +29,12 @@ variable "labels" {
   default     = {}
 }
 
+variable "tags" {
+  description = "List of network tags to assign to daos-client instances"
+  type        = list(any)
+  default     = ["daos-client"]
+}
+
 variable "os_family" {
   description = "OS GCP image family"
   default     = "daos-client-hpc-rocky-8"

--- a/terraform/modules/daos_client/versions.tf
+++ b/terraform/modules/daos_client/versions.tf
@@ -16,7 +16,13 @@
 terraform {
   required_version = ">= 0.14.5"
   required_providers {
-    google      = ">= 3.54.0"
-    google-beta = ">= 4.16.0"
+    google = {
+      source  = "hashicorp/google"
+      version = "5.5.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "5.5.0"
+    }
   }
 }

--- a/terraform/modules/daos_server/README.md
+++ b/terraform/modules/daos_server/README.md
@@ -28,15 +28,15 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.5 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.54.0 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.16.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | 5.5.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | 5.5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 3.54.0 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 4.16.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 5.5.0 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | 5.5.0 |
 
 ## Modules
 
@@ -46,13 +46,13 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [google-beta_google_compute_instance.named_instances](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_compute_instance) | resource |
-| [google_compute_disk.daos_server_boot_disk](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk) | resource |
-| [google_secret_manager_secret.daos_ca](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
-| [google_secret_manager_secret_iam_policy.daos_ca_secret_policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_policy) | resource |
-| [google_compute_default_service_account.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_default_service_account) | data source |
-| [google_compute_image.os_image](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
-| [google_iam_policy.daos_ca_secret_version_manager](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/iam_policy) | data source |
+| [google-beta_google_compute_instance.named_instances](https://registry.terraform.io/providers/hashicorp/google-beta/5.5.0/docs/resources/google_compute_instance) | resource |
+| [google_compute_disk.daos_server_boot_disk](https://registry.terraform.io/providers/hashicorp/google/5.5.0/docs/resources/compute_disk) | resource |
+| [google_secret_manager_secret.daos_ca](https://registry.terraform.io/providers/hashicorp/google/5.5.0/docs/resources/secret_manager_secret) | resource |
+| [google_secret_manager_secret_iam_policy.daos_ca_secret_policy](https://registry.terraform.io/providers/hashicorp/google/5.5.0/docs/resources/secret_manager_secret_iam_policy) | resource |
+| [google_compute_default_service_account.default](https://registry.terraform.io/providers/hashicorp/google/5.5.0/docs/data-sources/compute_default_service_account) | data source |
+| [google_compute_image.os_image](https://registry.terraform.io/providers/hashicorp/google/5.5.0/docs/data-sources/compute_image) | data source |
+| [google_iam_policy.daos_ca_secret_version_manager](https://registry.terraform.io/providers/hashicorp/google/5.5.0/docs/data-sources/iam_policy) | data source |
 
 ## Inputs
 
@@ -79,6 +79,7 @@ No modules.
 | <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string,<br>    scopes = set(string)<br>  })</pre> | <pre>{<br>  "email": null,<br>  "scopes": [<br>    "https://www.googleapis.com/auth/devstorage.read_only",<br>    "https://www.googleapis.com/auth/logging.write",<br>    "https://www.googleapis.com/auth/monitoring.write",<br>    "https://www.googleapis.com/auth/servicecontrol",<br>    "https://www.googleapis.com/auth/service.management.readonly",<br>    "https://www.googleapis.com/auth/trace.append",<br>    "https://www.googleapis.com/auth/cloud-platform"<br>  ]<br>}</pre> | no |
 | <a name="input_subnetwork_name"></a> [subnetwork\_name](#input\_subnetwork\_name) | Name of the GCP sub-network to use | `string` | `"default"` | no |
 | <a name="input_subnetwork_project"></a> [subnetwork\_project](#input\_subnetwork\_project) | The GCP project where the subnetwork is defined | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Set of key/value label pairs to assign to daos-server instances | `list(any)` | <pre>[<br>  "daos-server"<br>]</pre> | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | The GCP zone to create and test resources in | `string` | n/a | yes |
 
 ## Outputs

--- a/terraform/modules/daos_server/main.tf
+++ b/terraform/modules/daos_server/main.tf
@@ -140,7 +140,7 @@ resource "google_compute_instance" "named_instances" {
   labels     = var.labels
 
   can_ip_forward = false
-  tags           = ["daos-server"]
+  tags           = var.tags
   machine_type   = var.machine_type
 
   metadata = {

--- a/terraform/modules/daos_server/scripts/client_install.sh
+++ b/terraform/modules/daos_server/scripts/client_install.sh
@@ -16,7 +16,7 @@
 #
 # Install DAOS Client package
 #
-DAOS_VERSION="${DAOS_VERSION:-2.2}"
+DAOS_VERSION="${DAOS_VERSION:-2.4}"
 
 set_vars() {
   # shellcheck disable=SC1091
@@ -26,22 +26,12 @@ set_vars() {
   OS_MAJOR_VERSION_ID="${ID,,}_${OS_MAJOR_VERSION}"
 
   case "${OS_MAJOR_VERSION_ID}" in
-    centos_7)
-      DAOS_OS_VERSION="CentOS7"
-      PKG_MGR="yum"
-      REPO_PATH=/etc/yum.repos.d
-      ;;
     almalinux_8|centos_8|rhel_8|rocky_8)
       DAOS_OS_VERSION="EL8"
       PKG_MGR="dnf"
       REPO_PATH=/etc/yum.repos.d
       ;;
     opensuse-leap_15)
-      if [[ "${OS_VERSION_ID}" == "opensuse-leap_15.4" ]]; then
-        log.error "Unsupported OS: ${OS_VERSION_ID}."
-        log.error "See https://daosio.atlassian.net/browse/DAOS-11637"
-        exit 1
-      fi
       DAOS_OS_VERSION="Leap15"
       PKG_MGR="zypper"
       REPO_PATH=/etc/zypp/repos.d

--- a/terraform/modules/daos_server/templates/daos_server.yml.tftpl
+++ b/terraform/modules/daos_server/templates/daos_server.yml.tftpl
@@ -15,9 +15,11 @@ transport_config:
 
 provider: ofi+tcp;ofi_rxm
 disable_vfio: true
+disable_vmd: true
 crt_timeout: ${crt_timeout}
 nr_hugepages: ${nr_hugepages}
 control_log_file: /var/daos/server.log
+helper_log_file: /var/daos/helper.log
 
 engines:
 -

--- a/terraform/modules/daos_server/variables.tf
+++ b/terraform/modules/daos_server/variables.tf
@@ -34,6 +34,12 @@ variable "labels" {
   default     = {}
 }
 
+variable "tags" {
+  description = "Set of key/value label pairs to assign to daos-server instances"
+  type        = list(any)
+  default     = ["daos-server"]
+}
+
 variable "os_family" {
   description = "OS GCP image family"
   type        = string

--- a/terraform/modules/daos_server/versions.tf
+++ b/terraform/modules/daos_server/versions.tf
@@ -17,7 +17,13 @@
 terraform {
   required_version = ">= 0.14.5"
   required_providers {
-    google      = ">= 3.54.0"
-    google-beta = ">= 4.16.0"
+    google = {
+      source  = "hashicorp/google"
+      version = "5.5.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "5.5.0"
+    }
   }
 }


### PR DESCRIPTION
Updated version of google tflint plugin
Updated default DAOS version to v2.4.0
Updated packer template so that it does not change the system python version Updated the google terraform provider to version 5.5.0 Added tags variable for DAOS instances to allow network tags to be added to instances Upgraded io500 version to io500 SC23
Added a python script that converts io500 results_summary.txt to results_summary.csv

Signed-off-by: Mark Olson <115657904+mark-olson@users.noreply.github.com>