### PR TITLE
DAOSGCP-220 Do not set tier-ratio when pool.size = *%

### DIFF
--- a/terraform/modules/daos_server/templates/pool_cont_create.inc.sh.tftpl
+++ b/terraform/modules/daos_server/templates/pool_cont_create.inc.sh.tftpl
@@ -10,7 +10,9 @@ if [[ "$${HOSTNAME,,}" == "$${FIRST_DAOS_SERVER_HOSTNAME,,}" ]]; then
     # Use older DAOS v2.2.x dmg options
     dmg pool create \
       --size=${pool.size} \
+      %{ if !can(regex(".*%.*", pool.size)) }
       --tier-ratio="${pool.tier_ratio}" \
+      %{~ endif ~}
       --user="${pool.user}" \
       --group="${pool.group}" \
       %{~ if length(pool.properties) != 0 ~}
@@ -21,7 +23,9 @@ if [[ "$${HOSTNAME,,}" == "$${FIRST_DAOS_SERVER_HOSTNAME,,}" ]]; then
   else
     dmg pool create \
       --size=${pool.size} \
+      %{ if !can(regex(".*%.*", pool.size)) }
       --tier-ratio="${pool.tier_ratio}" \
+      %{~ endif ~}
       --user="${pool.user}" \
       --group="${pool.group}" \
       %{~ if length(pool.properties) != 0 ~}
@@ -55,7 +59,6 @@ if [[ "$${HOSTNAME,,}" == "$${FIRST_DAOS_SERVER_HOSTNAME,,}" ]]; then
       "${pool.name}" \
       "${container.name}"
   fi
-
 
       %{~ for acl in container.acls ~}
   daos cont update-acl "${pool.name}" "${container.name}" --entry "${acl}"

--- a/terraform/modules/daos_server/templates/storage_format.inc.sh.tftpl
+++ b/terraform/modules/daos_server/templates/storage_format.inc.sh.tftpl
@@ -1,5 +1,6 @@
 if [[ "$${HOSTNAME,,}" == "$${FIRST_DAOS_SERVER_HOSTNAME,,}" ]]; then
-  # Wait for servers to start
+  echo "Waiting for servers to start ..."
+  echo "servers = '${servers}'"
   until dmg network scan | grep --fixed-strings "${servers}"
   do
     sleep 5


### PR DESCRIPTION
Added a check for the % in the pool.size variable.

If pool.size contains a % character the --tier-ratio option is not used when creating pools.

Signed-off-by: Mark Olson <115657904+mark-olson@users.noreply.github.com>