### PR TITLE
DAOSGCP-222 Remove variables that specify SCM size and hugepages

### DIFF
--- a/terraform/examples/daos_cluster/README.md
+++ b/terraform/examples/daos_cluster/README.md
@@ -84,7 +84,6 @@ No resources.
 | <a name="input_region"></a> [region](#input\_region) | The GCP region | `string` | n/a | yes |
 | <a name="input_server_daos_crt_timeout"></a> [server\_daos\_crt\_timeout](#input\_server\_daos\_crt\_timeout) | crt\_timeout | `number` | `300` | no |
 | <a name="input_server_daos_disk_count"></a> [server\_daos\_disk\_count](#input\_server\_daos\_disk\_count) | Number of local ssd's to use | `number` | `16` | no |
-| <a name="input_server_daos_scm_size"></a> [server\_daos\_scm\_size](#input\_server\_daos\_scm\_size) | scm\_size | `number` | `200` | no |
 | <a name="input_server_gvnic"></a> [server\_gvnic](#input\_server\_gvnic) | Use Google Virtual NIC (gVNIC) network interface | `bool` | `false` | no |
 | <a name="input_server_instance_base_name"></a> [server\_instance\_base\_name](#input\_server\_instance\_base\_name) | Base name for DAOS server instances | `string` | `"daos-server"` | no |
 | <a name="input_server_labels"></a> [server\_labels](#input\_server\_labels) | Set of key/value label pairs to assign to daos-server instances | `any` | `{}` | no |

--- a/terraform/examples/daos_cluster/main.tf
+++ b/terraform/examples/daos_cluster/main.tf
@@ -38,7 +38,6 @@ module "daos_server" {
   os_disk_size_gb     = var.server_os_disk_size_gb
   daos_disk_count     = var.server_daos_disk_count
   daos_crt_timeout    = var.server_daos_crt_timeout
-  daos_scm_size       = var.server_daos_scm_size
   service_account     = var.server_service_account
   pools               = var.server_pools
   gvnic               = var.server_gvnic

--- a/terraform/examples/daos_cluster/terraform.tfvars.perf.example
+++ b/terraform/examples/daos_cluster/terraform.tfvars.perf.example
@@ -12,7 +12,6 @@ zone                       = "<zone>"
 
 server_machine_type        = "n2-standard-16"
 server_daos_disk_count     = 4
-server_daos_scm_size       = 45
 server_number_of_instances = 4
 
 client_number_of_instances = 16

--- a/terraform/examples/daos_cluster/terraform.tfvars.tco.example
+++ b/terraform/examples/daos_cluster/terraform.tfvars.tco.example
@@ -12,7 +12,6 @@ zone                       = "<zone>"
 
 server_machine_type        = "n2-custom-36-215040"
 server_daos_disk_count     = 16
-server_daos_scm_size       = 180
 server_number_of_instances = 4
 
 client_number_of_instances = 16

--- a/terraform/examples/daos_cluster/variables.tf
+++ b/terraform/examples/daos_cluster/variables.tf
@@ -138,12 +138,6 @@ variable "server_preemptible" {
   type        = string
 }
 
-variable "server_daos_scm_size" {
-  description = "scm_size"
-  default     = 200
-  type        = number
-}
-
 variable "server_daos_crt_timeout" {
   description = "crt_timeout"
   default     = 300

--- a/terraform/examples/io500/README.md
+++ b/terraform/examples/io500/README.md
@@ -123,7 +123,7 @@ No resources.
 | <a name="input_region"></a> [region](#input\_region) | The GCP region | `string` | n/a | yes |
 | <a name="input_server_daos_crt_timeout"></a> [server\_daos\_crt\_timeout](#input\_server\_daos\_crt\_timeout) | crt\_timeout | `number` | `300` | no |
 | <a name="input_server_daos_disk_count"></a> [server\_daos\_disk\_count](#input\_server\_daos\_disk\_count) | Number of local ssd's to use | `number` | `16` | no |
-| <a name="input_server_daos_scm_size"></a> [server\_daos\_scm\_size](#input\_server\_daos\_scm\_size) | scm\_size | `number` | `200` | no |
+| <a name="input_server_daos_scm_size"></a> [server\_daos\_scm\_size](#input\_server\_daos\_scm\_size) | scm\_size | `number` | `null` | no |
 | <a name="input_server_gvnic"></a> [server\_gvnic](#input\_server\_gvnic) | Use Google Virtual NIC (gVNIC) network interface | `bool` | `false` | no |
 | <a name="input_server_instance_base_name"></a> [server\_instance\_base\_name](#input\_server\_instance\_base\_name) | Base name for DAOS server instances | `string` | `"daos-server"` | no |
 | <a name="input_server_labels"></a> [server\_labels](#input\_server\_labels) | Set of key/value label pairs to assign to daos-server instances | `any` | `{}` | no |

--- a/terraform/examples/io500/variables.tf
+++ b/terraform/examples/io500/variables.tf
@@ -141,7 +141,7 @@ variable "server_preemptible" {
 
 variable "server_daos_scm_size" {
   description = "scm_size"
-  default     = 200
+  default     = null
   type        = number
 }
 

--- a/terraform/modules/daos_server/README.md
+++ b/terraform/modules/daos_server/README.md
@@ -61,7 +61,7 @@ No modules.
 | <a name="input_allow_insecure"></a> [allow\_insecure](#input\_allow\_insecure) | Sets the allow\_insecure setting in the transport\_config section of the daos\_*.yml files | `bool` | `false` | no |
 | <a name="input_daos_crt_timeout"></a> [daos\_crt\_timeout](#input\_daos\_crt\_timeout) | crt\_timeout | `number` | `300` | no |
 | <a name="input_daos_disk_count"></a> [daos\_disk\_count](#input\_daos\_disk\_count) | Number of local ssd's to use | `number` | `16` | no |
-| <a name="input_daos_scm_size"></a> [daos\_scm\_size](#input\_daos\_scm\_size) | scm\_size | `number` | `200` | no |
+| <a name="input_daos_scm_size"></a> [daos\_scm\_size](#input\_daos\_scm\_size) | scm\_size | `number` | `null` | no |
 | <a name="input_gvnic"></a> [gvnic](#input\_gvnic) | Use Google Virtual NIC (gVNIC) network interface | `bool` | `false` | no |
 | <a name="input_instance_base_name"></a> [instance\_base\_name](#input\_instance\_base\_name) | Base name for DAOS server instances | `string` | `"daos-server"` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Set of key/value label pairs to assign to daos-server instances | `any` | `{}` | no |

--- a/terraform/modules/daos_server/main.tf
+++ b/terraform/modules/daos_server/main.tf
@@ -22,13 +22,11 @@ locals {
   max_aps            = var.number_of_instances > 5 ? 5 : (var.number_of_instances % 2) == 1 ? var.number_of_instances : var.number_of_instances - 1
   access_points      = formatlist("%s-%04s", var.instance_base_name, range(1, local.max_aps + 1))
   scm_size           = var.daos_scm_size
-  # To get nr_hugepages value: (targets * 1Gib) / hugepagesize
-  huge_pages        = (var.daos_disk_count * 1048576) / 2048
-  targets           = var.daos_disk_count
-  crt_timeout       = var.daos_crt_timeout
-  daos_ca_secret_id = basename(google_secret_manager_secret.daos_ca.id)
-  allow_insecure    = var.allow_insecure
-  pools             = var.pools
+  targets            = var.daos_disk_count
+  crt_timeout        = var.daos_crt_timeout
+  daos_ca_secret_id  = basename(google_secret_manager_secret.daos_ca.id)
+  allow_insecure     = var.allow_insecure
+  pools              = var.pools
 
   # Google Virtual NIC (gVNIC) network interface
   nic_type                    = var.gvnic ? "GVNIC" : "VIRTIO_NET"
@@ -40,7 +38,6 @@ locals {
       access_points  = local.access_points
       targets        = local.targets
       scm_size       = local.scm_size
-      nr_hugepages   = local.huge_pages
       crt_timeout    = local.crt_timeout
       allow_insecure = local.allow_insecure
     }

--- a/terraform/modules/daos_server/templates/daos_server.yml.tftpl
+++ b/terraform/modules/daos_server/templates/daos_server.yml.tftpl
@@ -17,7 +17,6 @@ provider: ofi+tcp;ofi_rxm
 disable_vfio: true
 disable_vmd: true
 crt_timeout: ${crt_timeout}
-nr_hugepages: ${nr_hugepages}
 control_log_file: /var/daos/server.log
 helper_log_file: /var/daos/helper.log
 
@@ -41,7 +40,9 @@ engines:
    -
       scm_mount: /var/daos/ram
       class: ram
+      %{ if scm_size != null }
       scm_size: ${scm_size}
+      %{ endif }
    -
       class: nvme
       bdev_list: ["0000:00:04.0"]

--- a/terraform/modules/daos_server/templates/pool_cont_create.inc.sh.tftpl
+++ b/terraform/modules/daos_server/templates/pool_cont_create.inc.sh.tftpl
@@ -11,7 +11,9 @@ if [[ "$${HOSTNAME,,}" == "$${FIRST_DAOS_SERVER_HOSTNAME,,}" ]]; then
     dmg pool create \
       --size=${pool.size} \
       %{ if !can(regex(".*%.*", pool.size)) }
+        %{ if pool.tier_ratio != null }
       --tier-ratio="${pool.tier_ratio}" \
+        %{~ endif ~}
       %{~ endif ~}
       --user="${pool.user}" \
       --group="${pool.group}" \

--- a/terraform/modules/daos_server/variables.tf
+++ b/terraform/modules/daos_server/variables.tf
@@ -132,7 +132,7 @@ variable "preemptible" {
 
 variable "daos_scm_size" {
   description = "scm_size"
-  default     = 200
+  default     = null
   type        = number
 }
 


### PR DESCRIPTION
Removed variables from examples that specify SCM size.

Removed hugepage settings since that is not needed in DAOS v2.4

Signed-off-by: Mark Olson <115657904+mark-olson@users.noreply.github.com>